### PR TITLE
Update README and STANDARDS about GHC versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,12 @@
 
 # What do I need?
 
-Our policy is to support the latest three GHC versions. At this time, they are:
+Our policy is to support the latest three GHC versions; see the Cabal file's
+`tested-with` field to see which exact versions are supported. This is enforced
+using `get-tested` in our CI.
 
-* 9.6.6
-* 9.8.4
-* 9.10.1
-
-Covenant is developed using the lowest version listed exclusively, but
-compatibility with higher versions listed above is assured by our CI. We support
-only [Tier 1
-platforms](https://gitlab.haskell.org/ghc/ghc/-/wikis/platforms#tier-1-platforms).
+We support only [Tier 1 platforms](https://gitlab.haskell.org/ghc/ghc/-/wikis/platforms#tier-1-platforms). 
+Covenant is developed using the lowest supported version.
 
 # License
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -7,6 +7,10 @@ to evolve as our needs change.
 
 # Changelog
 
+## 31/01/2025
+
+* Add note about supporting the latest three GHCs
+
 ## 23/01/2025
 
 * Add section on dependencies
@@ -343,6 +347,25 @@ broken in more recent versions.
 For all other libraries, there are few, if any, guarantees of stability. Thus,
 they should be 'locked' to a specific version, to ensure that behaviour
 continues to make sense.
+
+## GHC
+
+The latest three versions of GHC MUST be supported; this MUST be noted in the
+`tested-with` field of the Cabal file for the project. 
+
+### Justification
+
+GHC as a tool changes a lot from release to release. This isn't just true of the
+compiler itself (as we often gain new features which are rarely, if ever,
+backported), but of the libraries it ships with (`base` and boot libraries),
+which are often incompatibly different with previous versions. Thus, _some_ kind
+of support window is essential, or it becomes difficult to maintain, or even
+make any decisions about what to support.
+
+The latest three GHC versions provide a good balance between allowing the most
+current features of the language, while also providing an older fallback for
+those who might need an older release due to dependencies not having migrated
+yet.
 
 ## CI
 


### PR DESCRIPTION
This ensures that we have one source of truth about what GHCs are and aren't supported, and that this source is enforced by our CI. Additionally, the standards now specifies that we must support only the latest three releases.