### PR TITLE
Improved ASG, zipper

### DIFF
--- a/covenant.cabal
+++ b/covenant.cabal
@@ -86,6 +86,7 @@ library
     Covenant.Prim
 
   other-modules:
+    Covenant.Internal.ASG
     Covenant.Internal.ASGBuilder
     Covenant.Internal.ASGNode
 

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -92,10 +92,10 @@ library
 
   build-depends:
     QuickCheck ==2.15.0.1,
-    algebraic-graphs ==0.7,
     bimap ==0.5.0,
     bytestring >=0.12.1.0 && <0.13,
     containers >=0.6.8 && <0.8,
+    enummapset ==0.7.3.0,
     mtl >=2.3.1 && <3,
     optics-core ==0.4.1.1,
     optics-th ==0.4.1,

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -23,7 +23,6 @@ module Covenant.ASG
     Bound,
     Ref (..),
     PrimCall (..),
-    ASGNode,
     ASGBuilder,
     Scope,
     ASG,
@@ -54,7 +53,7 @@ import Covenant.Internal.ASGBuilder
     prim,
   )
 import Covenant.Internal.ASGNode
-  ( ASGNode (Lam, Let),
+  ( ASGNodeInternal (LamInternal, LetInternal),
     Arg (Arg),
     Bound (Bound),
     Id,
@@ -136,7 +135,7 @@ lam ::
   ASGBuilder Id
 lam Scope f = do
   res <- f Scope
-  idOf . Lam $ res
+  idOf . LamInternal $ res
 
 -- | Given a proof of scope, a 'Ref' to an expression to bind to, and a function
 -- to construct a @let@-binding body using a \'larger\' proof of scope, construct
@@ -161,4 +160,4 @@ letBind ::
   ASGBuilder Id
 letBind Scope r f = do
   res <- f Scope
-  idOf . Let r $ res
+  idOf . LetInternal r $ res

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -- |
 -- Module: Covenant.ASG
@@ -24,6 +25,7 @@ module Covenant.ASG
     Ref (..),
     PrimCall (..),
     ASGBuilder,
+    ASGNode (Lit, Lam, Prim, App, Let),
     Scope,
     ASG,
 
@@ -53,12 +55,17 @@ import Covenant.Internal.ASGBuilder
     prim,
   )
 import Covenant.Internal.ASGNode
-  ( ASGNodeInternal (LamInternal, LetInternal),
+  ( ASGNode (LamInternal, LetInternal),
     Arg (Arg),
     Bound (Bound),
     Id,
     PrimCall (PrimCallOne, PrimCallSix, PrimCallThree, PrimCallTwo),
     Ref (ABound, AnArg, AnId),
+    pattern App,
+    pattern Lam,
+    pattern Let,
+    pattern Lit,
+    pattern Prim,
   )
 import Data.Proxy (Proxy (Proxy))
 import GHC.TypeNats (CmpNat, KnownNat, natVal, type (+))

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -28,8 +28,11 @@ module Covenant.ASG
     ASGNode (Lit, Lam, Prim, App, Let),
     Scope,
     ASG,
+    ASGZipper,
 
     -- * Functions
+
+    -- ** Scope construction
     emptyScope,
 
     -- ** Builder functionality
@@ -43,10 +46,30 @@ module Covenant.ASG
 
     -- ** Compile
     compileASG,
+
+    -- ** Walking the ASG
+    openASGZipper,
+    closeASGZipper,
+    viewASGZipper,
+    downASGZipper,
+    leftASGZipper,
+    rightASGZipper,
+    upASGZipper,
   )
 where
 
-import Covenant.Internal.ASG (ASG, compileASG)
+import Covenant.Internal.ASG
+  ( ASG,
+    ASGZipper,
+    closeASGZipper,
+    compileASG,
+    downASGZipper,
+    leftASGZipper,
+    openASGZipper,
+    rightASGZipper,
+    upASGZipper,
+    viewASGZipper,
+  )
 import Covenant.Internal.ASGBuilder
   ( ASGBuilder,
     app,

--- a/src/Covenant/Internal/ASG.hs
+++ b/src/Covenant/Internal/ASG.hs
@@ -1,0 +1,101 @@
+module Covenant.Internal.ASG
+  ( ASG (..),
+    compileASG,
+  )
+where
+
+import Algebra.Graph.Acyclic.AdjacencyMap
+  ( AdjacencyMap,
+    toAcyclic,
+    vertex,
+  )
+import Algebra.Graph.AdjacencyMap qualified as Cyclic
+import Control.Monad.State.Strict (runState)
+import Covenant.Internal.ASGBuilder
+  ( ASGBuilder (ASGBuilder),
+    ASGBuilderState (ASGBuilderState),
+  )
+import Covenant.Internal.ASGNode
+  ( ASGNode
+      ( App,
+        Lam,
+        Let,
+        Lit,
+        Prim
+      ),
+    Id,
+    PrimCall
+      ( PrimCallOne,
+        PrimCallSix,
+        PrimCallThree,
+        PrimCallTwo
+      ),
+    Ref (ABound, AnArg, AnId),
+  )
+import Data.Bimap (Bimap)
+import Data.Bimap qualified as Bimap
+import Data.Maybe (mapMaybe)
+
+-- | A Covenant program, represented as an acyclic graph.
+--
+-- @since 1.0.0
+data ASG = ASG (Id, ASGNode) (AdjacencyMap (Id, ASGNode))
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
+
+-- | Given an 'Id' result in a builder monad, compile the computation that 'Id'
+-- refers to into an 'ASG'.
+--
+-- @since 1.0.0
+compileASG :: ASGBuilder Id -> Maybe ASG
+compileASG (ASGBuilder comp) = do
+  let (start, ASGBuilderState binds) = runState comp (ASGBuilderState Bimap.empty)
+  if Bimap.size binds == 1
+    then do
+      -- This cannot fail, but the type system can't show it
+      initial <- (start,) <$> Bimap.lookup start binds
+      pure . ASG initial . vertex $ initial
+    else do
+      let asGraph = Cyclic.edges . go binds $ start
+      -- This cannot fail, but the type system can't show it
+      acyclic <- toAcyclic asGraph
+      -- Same as above
+      initial <- (start,) <$> Bimap.lookup start binds
+      pure . ASG initial $ acyclic
+  where
+    go ::
+      Bimap Id ASGNode ->
+      Id ->
+      [((Id, ASGNode), (Id, ASGNode))]
+    go binds curr = case Bimap.lookup curr binds of
+      Nothing -> []
+      Just e ->
+        let idList = toIdList e
+            stepdown i = case Bimap.lookup i binds of
+              Nothing -> []
+              Just e' -> ((curr, e), (i, e')) : go binds i
+         in concatMap stepdown idList
+
+-- Helpers
+
+toIdList :: ASGNode -> [Id]
+toIdList = \case
+  Lit _ -> []
+  Prim p -> mapMaybe refToId $ case p of
+    PrimCallOne _ r -> [r]
+    PrimCallTwo _ r1 r2 -> [r1, r2]
+    PrimCallThree _ r1 r2 r3 -> [r1, r2, r3]
+    PrimCallSix _ r1 r2 r3 r4 r5 r6 -> [r1, r2, r3, r4, r5, r6]
+  Lam body -> mapMaybe refToId [body]
+  Let x body -> mapMaybe refToId [x, body]
+  App f x -> mapMaybe refToId [f, x]
+
+refToId :: Ref -> Maybe Id
+refToId = \case
+  AnArg _ -> Nothing
+  AnId i -> Just i
+  ABound _ -> Nothing

--- a/src/Covenant/Internal/ASG.hs
+++ b/src/Covenant/Internal/ASG.hs
@@ -1,6 +1,17 @@
 module Covenant.Internal.ASG
   ( ASG (..),
+    Tape (..),
+    ASGZipper (..),
     compileASG,
+    openASGZipper,
+    viewASGZipper,
+    downASGZipper,
+    leftASGZipper,
+    rightASGZipper,
+    upASGZipper,
+    closeASGZipper,
+    tapeLeft,
+    tapeRight,
   )
 where
 
@@ -26,6 +37,7 @@ import Covenant.Internal.ASGNode
         PrimCallTwo
       ),
     Ref (AnId),
+    childIds,
   )
 import Data.Bimap (Bimap)
 import Data.Bimap qualified as Bimap
@@ -43,7 +55,90 @@ data ASG = ASG Id (EnumMap Id ASGNode)
       Show
     )
 
--- | @since 1.0.0
+-- | A zipper for the ASG, allowing traversal.
+--
+-- @since 1.0.0
+data ASGZipper = ASGZipper (EnumMap Id ASGNode) [Tape] Tape
+
+-- | \'Unzip\' an 'ASG', starting the traversal at the source node corresponding
+-- to the \'toplevel\' computation.
+--
+-- @since 1.0.0
+openASGZipper :: ASG -> ASGZipper
+openASGZipper (ASG start binds) = ASGZipper binds [] . Tape [] start $ []
+
+-- | \'Rezip\' an 'ASG'.
+--
+-- = Note
+--
+-- As the 'ASGZipper' is currently read-only, this operation technically doesn't
+-- have to exist. However, we provide it for future use, in case modification
+-- becomes possible.
+--
+-- @since 1.0.0
+closeASGZipper :: ASGZipper -> ASG
+closeASGZipper z@(ASGZipper binds parents curr) = case parents of
+  [] -> case curr of
+    -- This only works as the ASG has a single source.
+    Tape _ currId _ -> ASG currId binds
+  _ -> closeASGZipper . upASGZipper $ z
+
+-- | View the node the 'ASGZipper' is currently focused on.
+--
+-- @since 1.0.0
+viewASGZipper :: ASGZipper -> ASGNode
+viewASGZipper (ASGZipper binds _ curr) = case curr of
+  Tape _ currId _ -> binds EnumMap.! currId
+
+-- | Move the 'ASGZipper' to the leftmost child of the current focus, if it
+-- exists. This bypasses any arguments or @let@-bindings; if no such children
+-- exist, nothing happens.
+--
+-- @since 1.0.0
+downASGZipper :: ASGZipper -> ASGZipper
+downASGZipper z@(ASGZipper binds parents curr) = case curr of
+  t@(Tape _ currId _) -> case childIds $ binds EnumMap.! currId of
+    [] -> z -- can't go anywhere
+    leftmost : rest -> ASGZipper binds (t : parents) . Tape [] leftmost $ rest
+
+-- | Move the 'ASGZipper' to the left sibling of the current focus, if it
+-- exists. This bypasses any arguments or @let@-bindings; if no such node
+-- exists, nothing happens.
+--
+-- @since 1.0.0
+leftASGZipper :: ASGZipper -> ASGZipper
+leftASGZipper (ASGZipper binds parents curr) =
+  ASGZipper binds parents (tapeLeft curr)
+
+-- | Move the 'ASGZipper' to the right sibling of the current focus, if it
+-- exists. This bypasses any arguments or @let@-bindings; if no such node
+-- exists, nothing happens.
+--
+-- @since 1.0.0
+rightASGZipper :: ASGZipper -> ASGZipper
+rightASGZipper (ASGZipper binds parents curr) =
+  ASGZipper binds parents (tapeRight curr)
+
+-- | Move the 'ASGZipper' to the parent of the current focus, if it exists. If
+-- we're at the root, nothing happens.
+--
+-- @since 1.0.0
+upASGZipper :: ASGZipper -> ASGZipper
+upASGZipper z@(ASGZipper binds parents _) = case parents of
+  [] -> z -- nowhere to go
+  parent : rest -> ASGZipper binds rest parent
+
+-- | Given an 'ASGBuilder' whose result is the 'Id' corresponding to the
+-- \'toplevel computation\' in the desired ASG, attempt to compile to an 'ASG'.
+--
+-- = Note
+--
+-- This currently cannot fail, despite the type specifying that it can. This
+-- stems from the fact that we don't statically know every lookup for every
+-- 'Id'. In practice, if you ever get 'Nothing' from this, something has gone
+-- very, /very/ wrong.
+--
+-- @since 1.0.0
 compileASG :: ASGBuilder Id -> Maybe ASG
 compileASG (ASGBuilder comp) = do
   let (start, ASGBuilderState binds) = runState comp (ASGBuilderState Bimap.empty)
@@ -90,3 +185,15 @@ allDescendants = \case
   LamInternal r -> queryAll [r]
   LetInternal rBind rBody -> queryAll [rBind, rBody]
   AppInternal rFun rArg -> queryAll [rFun, rArg]
+
+data Tape = Tape [Id] Id [Id]
+
+tapeLeft :: Tape -> Tape
+tapeLeft t@(Tape lefts curr rights) = case lefts of
+  [] -> t -- can't move
+  rightmostLeft : rest -> Tape rest rightmostLeft (curr : rights)
+
+tapeRight :: Tape -> Tape
+tapeRight t@(Tape lefts curr rights) = case rights of
+  [] -> t -- can't move
+  leftmostRight : rest -> Tape (curr : lefts) leftmostRight rest

--- a/src/Covenant/Internal/ASG.hs
+++ b/src/Covenant/Internal/ASG.hs
@@ -16,12 +16,12 @@ import Covenant.Internal.ASGBuilder
     ASGBuilderState (ASGBuilderState),
   )
 import Covenant.Internal.ASGNode
-  ( ASGNode
-      ( App,
-        Lam,
-        Let,
-        Lit,
-        Prim
+  ( ASGNodeInternal
+      ( AppInternal,
+        LamInternal,
+        LetInternal,
+        LitInternal,
+        PrimInternal
       ),
     Id,
     PrimCall
@@ -39,7 +39,7 @@ import Data.Maybe (mapMaybe)
 -- | A Covenant program, represented as an acyclic graph.
 --
 -- @since 1.0.0
-data ASG = ASG (Id, ASGNode) (AdjacencyMap (Id, ASGNode))
+data ASG = ASG (Id, ASGNodeInternal) (AdjacencyMap (Id, ASGNodeInternal))
   deriving stock
     ( -- | @since 1.0.0
       Eq,
@@ -68,9 +68,9 @@ compileASG (ASGBuilder comp) = do
       pure . ASG initial $ acyclic
   where
     go ::
-      Bimap Id ASGNode ->
+      Bimap Id ASGNodeInternal ->
       Id ->
-      [((Id, ASGNode), (Id, ASGNode))]
+      [((Id, ASGNodeInternal), (Id, ASGNodeInternal))]
     go binds curr = case Bimap.lookup curr binds of
       Nothing -> []
       Just e ->
@@ -82,17 +82,17 @@ compileASG (ASGBuilder comp) = do
 
 -- Helpers
 
-toIdList :: ASGNode -> [Id]
+toIdList :: ASGNodeInternal -> [Id]
 toIdList = \case
-  Lit _ -> []
-  Prim p -> mapMaybe refToId $ case p of
+  LitInternal _ -> []
+  PrimInternal p -> mapMaybe refToId $ case p of
     PrimCallOne _ r -> [r]
     PrimCallTwo _ r1 r2 -> [r1, r2]
     PrimCallThree _ r1 r2 r3 -> [r1, r2, r3]
     PrimCallSix _ r1 r2 r3 r4 r5 r6 -> [r1, r2, r3, r4, r5, r6]
-  Lam body -> mapMaybe refToId [body]
-  Let x body -> mapMaybe refToId [x, body]
-  App f x -> mapMaybe refToId [f, x]
+  LamInternal body -> mapMaybe refToId [body]
+  LetInternal x body -> mapMaybe refToId [x, body]
+  AppInternal f x -> mapMaybe refToId [f, x]
 
 refToId :: Ref -> Maybe Id
 refToId = \case

--- a/src/Covenant/Internal/ASG.hs
+++ b/src/Covenant/Internal/ASG.hs
@@ -4,19 +4,14 @@ module Covenant.Internal.ASG
   )
 where
 
-import Algebra.Graph.Acyclic.AdjacencyMap
-  ( AdjacencyMap,
-    toAcyclic,
-    vertex,
-  )
-import Algebra.Graph.AdjacencyMap qualified as Cyclic
+import Control.Monad.Reader (ReaderT, ask, runReaderT)
 import Control.Monad.State.Strict (runState)
 import Covenant.Internal.ASGBuilder
   ( ASGBuilder (ASGBuilder),
     ASGBuilderState (ASGBuilderState),
   )
 import Covenant.Internal.ASGNode
-  ( ASGNodeInternal
+  ( ASGNode
       ( AppInternal,
         LamInternal,
         LetInternal,
@@ -30,16 +25,17 @@ import Covenant.Internal.ASGNode
         PrimCallThree,
         PrimCallTwo
       ),
-    Ref (ABound, AnArg, AnId),
+    Ref (AnId),
   )
 import Data.Bimap (Bimap)
 import Data.Bimap qualified as Bimap
-import Data.Maybe (mapMaybe)
+import Data.EnumMap.Strict (EnumMap)
+import Data.EnumMap.Strict qualified as EnumMap
 
 -- | A Covenant program, represented as an acyclic graph.
 --
 -- @since 1.0.0
-data ASG = ASG (Id, ASGNodeInternal) (AdjacencyMap (Id, ASGNodeInternal))
+data ASG = ASG Id (EnumMap Id ASGNode)
   deriving stock
     ( -- | @since 1.0.0
       Eq,
@@ -47,55 +43,50 @@ data ASG = ASG (Id, ASGNodeInternal) (AdjacencyMap (Id, ASGNodeInternal))
       Show
     )
 
--- | Given an 'Id' result in a builder monad, compile the computation that 'Id'
--- refers to into an 'ASG'.
---
--- @since 1.0.0
+-- | @since 1.0.0
 compileASG :: ASGBuilder Id -> Maybe ASG
 compileASG (ASGBuilder comp) = do
   let (start, ASGBuilderState binds) = runState comp (ASGBuilderState Bimap.empty)
-  if Bimap.size binds == 1
-    then do
-      -- This cannot fail, but the type system can't show it
-      initial <- (start,) <$> Bimap.lookup start binds
-      pure . ASG initial . vertex $ initial
-    else do
-      let asGraph = Cyclic.edges . go binds $ start
-      -- This cannot fail, but the type system can't show it
-      acyclic <- toAcyclic asGraph
-      -- Same as above
-      initial <- (start,) <$> Bimap.lookup start binds
-      pure . ASG initial $ acyclic
+  u <- Bimap.lookup start binds
+  built <- runReaderT (go start u) binds
+  pure . ASG start $ built
   where
+    -- Note (Koz, 04/02/2025): We rely on the monoidal behaviour of `EnumMap`
+    -- for accumulation here, instead of carrying around an explicit
+    -- accumulator. This is normally a bit risky, as the default behaviour of
+    -- `<>` on `Map`s of any flavour throws away values on key collisions.
+    -- However, we know that `ASGBuilder` uses a `Bimap`, thus making key
+    -- collisions impossible; therefore, we can use `<>` without concern.
     go ::
-      Bimap Id ASGNodeInternal ->
       Id ->
-      [((Id, ASGNodeInternal), (Id, ASGNodeInternal))]
-    go binds curr = case Bimap.lookup curr binds of
-      Nothing -> []
-      Just e ->
-        let idList = toIdList e
-            stepdown i = case Bimap.lookup i binds of
-              Nothing -> []
-              Just e' -> ((curr, e), (i, e')) : go binds i
-         in concatMap stepdown idList
+      ASGNode ->
+      ReaderT (Bimap Id ASGNode) Maybe (EnumMap Id ASGNode)
+    go currId currNode = do
+      let currMap = EnumMap.singleton currId currNode
+      descendants <- allDescendants currNode
+      traversed <- traverse (uncurry go) descendants
+      pure . EnumMap.unions $ currMap : traversed
 
 -- Helpers
 
-toIdList :: ASGNodeInternal -> [Id]
-toIdList = \case
-  LitInternal _ -> []
-  PrimInternal p -> mapMaybe refToId $ case p of
-    PrimCallOne _ r -> [r]
-    PrimCallTwo _ r1 r2 -> [r1, r2]
-    PrimCallThree _ r1 r2 r3 -> [r1, r2, r3]
-    PrimCallSix _ r1 r2 r3 r4 r5 r6 -> [r1, r2, r3, r4, r5, r6]
-  LamInternal body -> mapMaybe refToId [body]
-  LetInternal x body -> mapMaybe refToId [x, body]
-  AppInternal f x -> mapMaybe refToId [f, x]
+-- Essentially `mapMaybe` but in a more general environment and taking apart
+-- `Ref`. We have to write it this way because a 'transformed' `mapMaybe` isn't
+-- a thing.
+queryAll :: [Ref] -> ReaderT (Bimap Id ASGNode) Maybe [(Id, ASGNode)]
+queryAll = \case
+  [] -> pure []
+  r : rs -> case r of
+    AnId i -> (:) . (i,) <$> (ask >>= Bimap.lookup i) <*> queryAll rs
+    _ -> queryAll rs
 
-refToId :: Ref -> Maybe Id
-refToId = \case
-  AnArg _ -> Nothing
-  AnId i -> Just i
-  ABound _ -> Nothing
+allDescendants :: ASGNode -> ReaderT (Bimap Id ASGNode) Maybe [(Id, ASGNode)]
+allDescendants = \case
+  LitInternal _ -> pure []
+  PrimInternal p -> case p of
+    PrimCallOne _ r1 -> queryAll [r1]
+    PrimCallTwo _ r1 r2 -> queryAll [r1, r2]
+    PrimCallThree _ r1 r2 r3 -> queryAll [r1, r2, r3]
+    PrimCallSix _ r1 r2 r3 r4 r5 r6 -> queryAll [r1, r2, r3, r4, r5, r6]
+  LamInternal r -> queryAll [r]
+  LetInternal rBind rBody -> queryAll [rBind, rBody]
+  AppInternal rFun rArg -> queryAll [rFun, rArg]

--- a/src/Covenant/Internal/ASG.hs
+++ b/src/Covenant/Internal/ASG.hs
@@ -44,10 +44,15 @@ import Data.Bimap qualified as Bimap
 import Data.EnumMap.Strict (EnumMap)
 import Data.EnumMap.Strict qualified as EnumMap
 
--- | A Covenant program, represented as an acyclic graph.
+-- | A Covenant program, represented as an acyclic graph with a single source
+-- node. We use the term /ASG/, standing for \'abstract syntax graph\' for this
+-- concept.
 --
 -- @since 1.0.0
-data ASG = ASG Id (EnumMap Id ASGNode)
+data ASG
+  = ASG
+      Id -- Source node reference: this is the 'starting point' of the ASG, or the 'toplevel computation'
+      (EnumMap Id ASGNode)
   deriving stock
     ( -- | @since 1.0.0
       Eq,

--- a/src/Covenant/Internal/ASGBuilder.hs
+++ b/src/Covenant/Internal/ASGBuilder.hs
@@ -15,7 +15,7 @@ import Control.Monad.State.Strict (State, gets, modify')
 import Control.Monad.Trans (lift)
 import Covenant.Constant (AConstant)
 import Covenant.Internal.ASGNode
-  ( ASGNodeInternal
+  ( ASGNode
       ( AppInternal,
         LamInternal,
         LitInternal,
@@ -48,8 +48,8 @@ import Test.QuickCheck.GenT
     sized,
   )
 
-newtype ASGBuilderState = ASGBuilderState {binds :: Bimap Id ASGNodeInternal}
-  deriving (Eq, Ord) via Bimap Id ASGNodeInternal
+newtype ASGBuilderState = ASGBuilderState {binds :: Bimap Id ASGNode}
+  deriving (Eq, Ord) via Bimap Id ASGNode
   deriving stock (Show)
 
 makeFieldLabelsNoPrefix ''ASGBuilderState
@@ -197,7 +197,7 @@ app f x = idOf (AppInternal f x)
 -- the current `ExprBuilder` context, this `Id` will be looked up and reused;
 -- otherwise, a fresh `Id` will be assigned, and the node cached to ensure we
 -- have a reference to it henceforth.
-idOf :: ASGNodeInternal -> ASGBuilder Id
+idOf :: ASGNode -> ASGBuilder Id
 idOf e = ASGBuilder $ do
   existingId <- gets (Bimap.lookupR e . view #binds)
   case existingId of

--- a/src/Covenant/Internal/ASGBuilder.hs
+++ b/src/Covenant/Internal/ASGBuilder.hs
@@ -15,7 +15,12 @@ import Control.Monad.State.Strict (State, gets, modify')
 import Control.Monad.Trans (lift)
 import Covenant.Constant (AConstant)
 import Covenant.Internal.ASGNode
-  ( ASGNode (App, Lam, Lit, Prim),
+  ( ASGNodeInternal
+      ( AppInternal,
+        LamInternal,
+        LitInternal,
+        PrimInternal
+      ),
     Arg (Arg),
     Id (Id),
     PrimCall
@@ -43,8 +48,8 @@ import Test.QuickCheck.GenT
     sized,
   )
 
-newtype ASGBuilderState = ASGBuilderState {binds :: Bimap Id ASGNode}
-  deriving (Eq, Ord) via Bimap Id ASGNode
+newtype ASGBuilderState = ASGBuilderState {binds :: Bimap Id ASGNodeInternal}
+  deriving (Eq, Ord) via Bimap Id ASGNodeInternal
   deriving stock (Show)
 
 makeFieldLabelsNoPrefix ''ASGBuilderState
@@ -133,7 +138,7 @@ instance Arbitrary (ASGBuilder Id) where
         -- would require existentialization (using something like `Some`), which
         -- doesn't really help us any (because we have full control anyway), but
         -- does make the code much harder to read and debug.
-        pure $ body >>= \bodyRef -> idOf (Lam bodyRef)
+        pure $ body >>= \bodyRef -> idOf (LamInternal bodyRef)
       -- Note (Koz, 21/01/25): This is essentially `local`, but because GenT
       -- isn't an instance of MonadReader, we have to write it by hand. We could
       -- have defined an orphan instance instead, but I figured it'd be better
@@ -169,13 +174,13 @@ instance Arbitrary (ASGBuilder Id) where
 --
 -- @since 1.0.0
 lit :: AConstant -> ASGBuilder Id
-lit = idOf . Lit
+lit = idOf . LitInternal
 
 -- | Construct a primitive function call.
 --
 -- @since 1.0.0
 prim :: PrimCall -> ASGBuilder Id
-prim = idOf . Prim
+prim = idOf . PrimInternal
 
 -- | Construct a function application. The first argument is (an expression
 -- evaluating to) a function, the second argument is (an expression evaluating
@@ -186,13 +191,13 @@ prim = idOf . Prim
 -- Currently, this does not verify that the first argument is indeed a function,
 -- nor that the second argument is appropriate.
 app :: Ref -> Ref -> ASGBuilder Id
-app f x = idOf (App f x)
+app f x = idOf (AppInternal f x)
 
 -- Given a node, return its unique `Id`. If this is a node we've seen before in
 -- the current `ExprBuilder` context, this `Id` will be looked up and reused;
 -- otherwise, a fresh `Id` will be assigned, and the node cached to ensure we
 -- have a reference to it henceforth.
-idOf :: ASGNode -> ASGBuilder Id
+idOf :: ASGNodeInternal -> ASGBuilder Id
 idOf e = ASGBuilder $ do
   existingId <- gets (Bimap.lookupR e . view #binds)
   case existingId of

--- a/src/Covenant/Internal/ASGNode.hs
+++ b/src/Covenant/Internal/ASGNode.hs
@@ -4,7 +4,7 @@ module Covenant.Internal.ASGNode
     Bound (..),
     Ref (..),
     PrimCall (..),
-    ASGNode (..),
+    ASGNodeInternal (..),
   )
 where
 
@@ -94,16 +94,13 @@ data PrimCall
       Show
     )
 
--- | A node in a Covenant program. Since Covenant programs are hash consed, they
--- form a graph, hence \'ASG\' - \'abstract syntax graph\'.
---
--- @since 1.0.0
-data ASGNode
-  = Lit AConstant
-  | Prim PrimCall
-  | Lam Ref
-  | Let Ref Ref
-  | App Ref Ref
+-- Used only by the ASGBuilder
+data ASGNodeInternal
+  = LitInternal AConstant
+  | PrimInternal PrimCall
+  | LamInternal Ref
+  | LetInternal Ref Ref
+  | AppInternal Ref Ref
   deriving stock
     ( -- | @since 1.0.0
       Eq,

--- a/src/Covenant/Internal/ASGNode.hs
+++ b/src/Covenant/Internal/ASGNode.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Covenant.Internal.ASGNode
   ( Id (..),
     Arg (..),
     Bound (..),
     Ref (..),
     PrimCall (..),
-    ASGNodeInternal (..),
+    ASGNode (..),
+    pattern Lit,
+    pattern Prim,
+    pattern Lam,
+    pattern Let,
+    pattern App,
   )
 where
 
@@ -20,7 +27,11 @@ newtype Id = Id Word64
     ( -- | @since 1.0.0
       Eq,
       -- | @since 1.0.0
-      Ord
+      Ord,
+      -- | Needed for internal reasons, even though this type class is terrible.
+      --
+      -- @since 1.0.0
+      Enum
     )
     via Word64
   deriving stock
@@ -95,7 +106,7 @@ data PrimCall
     )
 
 -- Used only by the ASGBuilder
-data ASGNodeInternal
+data ASGNode
   = LitInternal AConstant
   | PrimInternal PrimCall
   | LamInternal Ref
@@ -109,3 +120,25 @@ data ASGNodeInternal
       -- | @since 1.0.0
       Show
     )
+
+-- | @since 1.0.0
+pattern Lit :: AConstant -> ASGNode
+pattern Lit c <- LitInternal c
+
+-- | @since 1.0.0
+pattern Prim :: PrimCall -> ASGNode
+pattern Prim p <- PrimInternal p
+
+-- | @since 1.0.0
+pattern Lam :: Ref -> ASGNode
+pattern Lam r <- LamInternal r
+
+-- | @since 1.0.0
+pattern Let :: Ref -> Ref -> ASGNode
+pattern Let rBind rBody <- LetInternal rBind rBody
+
+-- | @since 1.0.0
+pattern App :: Ref -> Ref -> ASGNode
+pattern App rFun rArg <- AppInternal rFun rArg
+
+{-# COMPLETE Lit, Prim, Lam, Let, App #-}


### PR DESCRIPTION
Closes #33 . Several changes happened here:

* `ASG` no longer uses `algebraic-graphs`, instead preferring a more serialization-friendly representation as an `EnumMap`.
* We have a zipper to traverse (but not yet modify) the `ASG`, which enables it to be used for something.

Future PRs can supplement this interface: it is quite low-level still, and probably not what we want to force people to use in all cases.