### PR TITLE
Fix CI to only run on PRs, fix -Werror not being picked up

### DIFF
--- a/.github/workflows/covenant.yml
+++ b/.github/workflows/covenant.yml
@@ -2,7 +2,6 @@ name: covenant
 
 on:
   pull_request:
-  push:
 
 jobs:
   generate-matrix:

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,5 @@
 packages: ./covenant.cabal
 
-documentation: true
-
 test-show-details: direct
 
 package covenant


### PR DESCRIPTION
This fixes a few minor issues. Firstly, we now only run CI on PRs, not every single push, which should save a lot of time. Secondly, `-Werror` was not being picked up due to a [Cabal bug](https://github.com/haskell/cabal/issues/10779), and the fix for this involves removing something we're not too worried about anyway.