### PR TITLE
Make cabal-gild not slow down CI

### DIFF
--- a/.github/workflows/covenant.yml
+++ b/.github/workflows/covenant.yml
@@ -46,6 +46,7 @@ jobs:
           fail-on: warning
   cabal-gild:
     name: "Check Cabal file with cabal-gild"
+    needs: [ormolu, hlint]
     runs-on: ubuntu-latest
     steps:
       - name: Set up environment
@@ -78,7 +79,7 @@ jobs:
         run: cabal-gild --input=covenant.cabal --mode=check
   tests:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
-    needs: [generate-matrix, ormolu, hlint, cabal-gild]
+    needs: [generate-matrix, ormolu, hlint]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}


### PR DESCRIPTION
Currently, because `cabal-gild` must be built from source, having it be a dependency of our compile-and-test matrix for all Tier 1 platforms slows down CI considerably. This PR breaks this dependency chain: now `cabal-gild` runs in parallel with the compile-and-test matrix.