### PR TITLE
CBPV type system basics and renamer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,7 @@
 packages: ./covenant.cabal
 
+tests: true
+
 test-show-details: direct
 
 package covenant

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -113,6 +113,7 @@ library
     mtl >=2.3.1 && <3,
     nonempty-vector ==0.2.4,
     optics-core ==0.4.1.1,
+    optics-extra ==0.4.2.1,
     optics-th ==0.4.1,
     quickcheck-instances ==0.3.32,
     quickcheck-transformer ==0.3.1.2,

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -110,6 +110,7 @@ library
     containers >=0.6.8 && <0.8,
     enummapset ==0.7.3.0,
     mtl >=2.3.1 && <3,
+    nonempty-vector ==0.2.4,
     optics-core ==0.4.1.1,
     optics-th ==0.4.1,
     quickcheck-instances ==0.3.32,
@@ -125,7 +126,12 @@ test-suite renaming
   import: test-lang
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  build-depends: bimap
+  build-depends:
+    bimap,
+    nonempty-vector,
+    quickcheck-instances ==0.3.32,
+    vector,
+
   hs-source-dirs: test/renaming
 
 -- Benchmarks

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -93,6 +93,7 @@ library
     Covenant.ASG
     Covenant.Constant
     Covenant.DeBruijn
+    Covenant.Index
     Covenant.Ledger
     Covenant.Prim
     Covenant.Type

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -73,6 +73,13 @@ common test-lang
     -rtsopts
     -with-rtsopts=-N
 
+  build-depends:
+    QuickCheck ==2.15.0.1,
+    covenant,
+    tasty ==1.5.3,
+    tasty-hunit ==0.10.2,
+    tasty-quickcheck ==0.11.1,
+
 common bench-lang
   import: lang
   ghc-options: -O2
@@ -87,6 +94,7 @@ library
     Covenant.Constant
     Covenant.Ledger
     Covenant.Prim
+    Covenant.Type
 
   other-modules:
     Covenant.Internal.ASG
@@ -113,4 +121,11 @@ library
   hs-source-dirs: src
 
 -- Tests
+test-suite renaming
+  import: test-lang
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  build-depends: bimap
+  hs-source-dirs: test/renaming
+
 -- Benchmarks

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -92,6 +92,7 @@ library
     Control.Monad.HashCons
     Covenant.ASG
     Covenant.Constant
+    Covenant.DeBruijn
     Covenant.Ledger
     Covenant.Prim
     Covenant.Type

--- a/src/Covenant/DeBruijn.hs
+++ b/src/Covenant/DeBruijn.hs
@@ -32,7 +32,11 @@ newtype DeBruijn = DeBruijn Word32
       Show
     )
 
--- | @since 1.0.0
+-- | Enables some manner of arithmetic with 'DeBruijn's. In this case, '<>' is
+-- analogous to '+', while @'stimes' b@ is analogous to scalar multiplication by
+-- @b@. Note that 'DeBruijn's cannot be scaled by negative numbers.
+--
+-- @since 1.0.0
 instance Semigroup DeBruijn where
   {-# INLINEABLE (<>) #-}
   DeBruijn x <> DeBruijn y = DeBruijn (x + y)

--- a/src/Covenant/DeBruijn.hs
+++ b/src/Covenant/DeBruijn.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Module: Covenant.DeBruijn
+--
+-- DeBruijn indexing type and helpers.
+module Covenant.DeBruijn
+  ( DeBruijn (Z, S),
+    asInt,
+  )
+where
+
+import Control.Monad (guard)
+import Data.Coerce (coerce)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Semigroup (Semigroup (sconcat, stimes), Sum (Sum))
+import Data.Word (Word32)
+
+-- | A DeBruijn index.
+--
+-- @since 1.0.0
+newtype DeBruijn = DeBruijn Word32
+  deriving
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Ord
+    )
+    via Word32
+  deriving stock
+    ( -- | @since 1.0.0
+      Show
+    )
+
+-- | @since 1.0.0
+instance Semigroup DeBruijn where
+  {-# INLINEABLE (<>) #-}
+  DeBruijn x <> DeBruijn y = DeBruijn (x + y)
+  {-# INLINEABLE sconcat #-}
+  sconcat = DeBruijn . sum . coerce @(NonEmpty DeBruijn) @(NonEmpty Word32)
+  {-# INLINEABLE stimes #-}
+  stimes b = DeBruijn . coerce . stimes b . coerce @_ @(Sum Word32)
+
+-- | @since 1.0.0
+instance Monoid DeBruijn where
+  {-# INLINEABLE mempty #-}
+  mempty = Z
+
+-- | The zero index.
+--
+-- @since 1.0.0
+pattern Z :: DeBruijn
+pattern Z <- DeBruijn 0
+  where
+    Z = DeBruijn 0
+
+-- | Successor to an index.
+--
+-- @since 1.0.0
+pattern S :: DeBruijn -> DeBruijn
+pattern S x <- (reduce -> Just x)
+  where
+    S (DeBruijn x) = DeBruijn (x + 1)
+
+{-# COMPLETE Z, S #-}
+
+-- | Convert a DeBruijn index into a (non-negative) 'Int'.
+--
+-- @since 1.0.0
+asInt :: DeBruijn -> Int
+asInt (DeBruijn i) = fromIntegral i
+
+-- Helpers
+
+reduce :: DeBruijn -> Maybe DeBruijn
+reduce (DeBruijn x) = DeBruijn (x - 1) <$ guard (x > 0)

--- a/src/Covenant/Index.hs
+++ b/src/Covenant/Index.hs
@@ -1,0 +1,100 @@
+-- | Module: Covenant.Index
+--
+-- Positional indexes, starting from 0.
+module Covenant.Index
+  ( Index,
+    intIndex,
+    ix0,
+    ix1,
+    ix2,
+    ix3,
+    ix4,
+  )
+where
+
+import Data.Bits (toIntegralSized)
+import Data.Coerce (coerce)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Semigroup (Semigroup (sconcat, stimes), Sum (Sum))
+import Data.Word (Word32)
+import Optics.Prism (Prism', prism)
+
+-- | A positional index, starting from zero.
+--
+-- @since 1.0.0
+newtype Index = Index Word32
+  deriving
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Ord
+    )
+    via Word32
+  deriving stock
+    ( -- | @since 1.0.0
+      Show
+    )
+
+-- | Enables some manner of arithmetic with 'Index'ess. In this case, '<>' is
+-- analogous to '+', while @'stimes' b@ is analogous to scalar multiplication by
+-- @b@. Note that 'Index'es cannot be scaled by negative numbers.
+--
+-- @since 1.0.0
+instance Semigroup Index where
+  {-# INLINEABLE (<>) #-}
+  Index x <> Index y = Index (x + y)
+  {-# INLINEABLE sconcat #-}
+  sconcat = Index . sum . coerce @(NonEmpty Index) @(NonEmpty Word32)
+  {-# INLINEABLE stimes #-}
+  stimes b = Index . coerce . stimes b . coerce @_ @(Sum Word32)
+
+-- | @since 1.0.0
+instance Monoid Index where
+  {-# INLINEABLE mempty #-}
+  mempty = Index 0
+
+-- | Helper to construct, and convert, 'Index'es and 'Int's. This is needed
+-- because unfortunately, the standard Haskell practice is to use 'Int' for
+-- indexes.
+--
+-- To use this, do one of the following:
+--
+-- * Construct with @'preview'@: for example, @'preview' intIndex 1@.
+-- * Destruct with @'review'@.
+--
+-- @since 1.0.0
+intIndex :: Prism' Int Index
+intIndex =
+  prism
+    (fromIntegral . coerce @_ @Word32)
+    (\i -> maybe (Left i) (Right . Index) . toIntegralSized $ i)
+
+-- | Helper for the first index.
+--
+-- @since 1.0.0
+ix0 :: Index
+ix0 = Index 0
+
+-- | Helper for the second index.
+--
+-- @since 1.0.0
+ix1 :: Index
+ix1 = Index 1
+
+-- | Helper for the third index.
+--
+-- @since 1.0.0
+ix2 :: Index
+ix2 = Index 2
+
+-- | Helper for the fourth index.
+--
+-- @since 1.0.0
+ix3 :: Index
+ix3 = Index 3
+
+-- | Helper for the fifth index.
+--
+-- @since 1.0.0
+ix4 :: Index
+ix4 = Index 4

--- a/src/Covenant/Index.hs
+++ b/src/Covenant/Index.hs
@@ -1,14 +1,21 @@
+{-# LANGUAGE RoleAnnotations #-}
+
 -- | Module: Covenant.Index
 --
 -- Positional indexes, starting from 0.
 module Covenant.Index
   ( Index,
+    Count,
     intIndex,
+    intCount,
     ix0,
+    count0,
     ix1,
+    count1,
     ix2,
+    count2,
     ix3,
-    ix4,
+    count3,
   )
 where
 
@@ -17,12 +24,14 @@ import Data.Coerce (coerce)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Semigroup (Semigroup (sconcat, stimes), Sum (Sum))
 import Data.Word (Word32)
+import GHC.TypeLits (Symbol)
 import Optics.Prism (Prism', prism)
 
--- | A positional index, starting from zero.
+-- | A positional index, starting from zero. The label allows distinguishing
+-- different flavours of indices.
 --
 -- @since 1.0.0
-newtype Index = Index Word32
+newtype Index (ofWhat :: Symbol) = Index Word32
   deriving
     ( -- | @since 1.0.0
       Eq,
@@ -35,21 +44,23 @@ newtype Index = Index Word32
       Show
     )
 
+type role Index nominal
+
 -- | Enables some manner of arithmetic with 'Index'ess. In this case, '<>' is
 -- analogous to '+', while @'stimes' b@ is analogous to scalar multiplication by
 -- @b@. Note that 'Index'es cannot be scaled by negative numbers.
 --
 -- @since 1.0.0
-instance Semigroup Index where
+instance Semigroup (Index ofWhat) where
   {-# INLINEABLE (<>) #-}
   Index x <> Index y = Index (x + y)
   {-# INLINEABLE sconcat #-}
-  sconcat = Index . sum . coerce @(NonEmpty Index) @(NonEmpty Word32)
+  sconcat = Index . sum . coerce @(NonEmpty (Index ofWhat)) @(NonEmpty Word32)
   {-# INLINEABLE stimes #-}
   stimes b = Index . coerce . stimes b . coerce @_ @(Sum Word32)
 
 -- | @since 1.0.0
-instance Monoid Index where
+instance Monoid (Index ofWhat) where
   {-# INLINEABLE mempty #-}
   mempty = Index 0
 
@@ -63,7 +74,7 @@ instance Monoid Index where
 -- * Destruct with @'review'@.
 --
 -- @since 1.0.0
-intIndex :: Prism' Int Index
+intIndex :: forall (ofWhat :: Symbol). Prism' Int (Index ofWhat)
 intIndex =
   prism
     (fromIntegral . coerce @_ @Word32)
@@ -72,29 +83,81 @@ intIndex =
 -- | Helper for the first index.
 --
 -- @since 1.0.0
-ix0 :: Index
+ix0 :: forall (ofWhat :: Symbol). Index ofWhat
 ix0 = Index 0
 
 -- | Helper for the second index.
 --
 -- @since 1.0.0
-ix1 :: Index
+ix1 :: forall (ofWhat :: Symbol). Index ofWhat
 ix1 = Index 1
 
 -- | Helper for the third index.
 --
 -- @since 1.0.0
-ix2 :: Index
+ix2 :: forall (ofWhat :: Symbol). Index ofWhat
 ix2 = Index 2
 
 -- | Helper for the fourth index.
 --
 -- @since 1.0.0
-ix3 :: Index
+ix3 :: forall (ofWhat :: Symbol). Index ofWhat
 ix3 = Index 3
 
--- | Helper for the fifth index.
+-- | An indicator of the cardinality of something. Meant to be paired with
+-- 'Index' to specify which unique something you mean.
 --
 -- @since 1.0.0
-ix4 :: Index
-ix4 = Index 4
+newtype Count (ofWhat :: Symbol) = Count Word32
+  deriving
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Ord
+    )
+    via Word32
+  deriving stock
+    ( -- | @since 1.0.0
+      Show
+    )
+
+type role Count nominal
+
+-- | Helper to construct, and convert, 'Count's and 'Int's. This is needed
+-- because unfortunately, sizes of things are usually 'Int's in Haskell.
+--
+-- To use this, do one of the following:
+--
+-- * Construct with @'preview'@: for example, @'preview' intCount 1@.
+-- * Destruct with @'review'@.
+--
+-- @since 1.0.0
+intCount :: forall (ofWhat :: Symbol). Prism' Int (Count ofWhat)
+intCount =
+  prism
+    (fromIntegral . coerce @_ @Word32)
+    (\i -> maybe (Left i) (Right . Count) . toIntegralSized $ i)
+
+-- | Helper for a count of zero items.
+--
+-- @since 1.0.0
+count0 :: forall (ofWhat :: Symbol). Count ofWhat
+count0 = Count 0
+
+-- | Helper for a count of one item.
+--
+-- @since 1.0.0
+count1 :: forall (ofWhat :: Symbol). Count ofWhat
+count1 = Count 1
+
+-- | Helper for a count of two items.
+--
+-- @since 1.0.0
+count2 :: forall (ofWhat :: Symbol). Count ofWhat
+count2 = Count 2
+
+-- | Helper for a count of three items.
+--
+-- @since 1.0.0
+count3 :: forall (ofWhat :: Symbol). Count ofWhat
+count3 = Count 3

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -20,29 +20,105 @@ import Data.Bimap qualified as Bimap
 import Data.Functor.Classes (Eq1 (liftEq))
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty)
-import Data.Word (Word64, Word8)
+import Data.Word (Word64)
 
-data AbstractTy = ForallAA | BoundAtScope Word8 Word8
-  deriving stock (Eq, Show)
+-- | A type abstraction.
+--
+-- = Important note
+--
+-- There is an implicit \'scope boundary\' in front of this. Thus, this
+-- construction can mean either:
+--
+-- * An untouchable (effectively @forall a . a@)
+-- * A single toplevel variable
+-- * A reference to another binding scope and index
+--
+-- The 'ForallAA' constructor plays the first two roles; which depends on the
+-- context. 'BoundAtScope' indicates instead how many scopes away it was bound,
+-- and also which binding we're referring to (first, second, etc).
+--
+-- @since 1.0.0
+data AbstractTy
+  = ForallAA
+  | BoundAtScope Word64 Word64
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
 
-data Renamed = CanSet Word8 | Can'tSet Word64
-  deriving stock (Eq, Ord, Show)
+-- | A renamed type abstraction. We separate them into two kinds:
+--
+-- * Ones we can decide on (that is, variables in the context of unification);
+-- and
+-- * Ones we /cannot/ decide on (either fixed in higher scopes than ours, or
+-- untouchable).
+--
+-- We use 'CanSet' plus an index for the first case; the second case is a unique
+-- index assigned by the renamer.
+--
+-- @since 1.0.0
+data Renamed = CanSet Word64 | Can'tSet Word64
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Ord,
+      -- | @since 1.0.0
+      Show
+    )
 
-data CompT (a :: Type) = CompT Word8 (NonEmpty (ValT a))
-  deriving stock (Eq, Show)
+-- | A computation type, with abstractions indicated by the type argument. In
+-- pretty much any case imaginable, this would be either 'AbstractTy' (in the
+-- ASG), or 'Renamed' (after renaming).
+--
+-- = Important note
+--
+-- This type has a \'type abstraction boundary\' just before it: the first field
+-- indicates how many type variables it binds.
+--
+-- The /last/ entry in the 'NonEmpty' indicates the return type.
+--
+-- @since 1.0.0
+data CompT (a :: Type) = CompT Word64 (NonEmpty (ValT a))
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
 
+-- Note (Koz, 04/03/2025): We use this for testing to compare for structural
+-- similarity.
 instance Eq1 CompT where
   {-# INLINEABLE liftEq #-}
   liftEq f (CompT abses1 xs) (CompT abses2 ys) =
     abses1 == abses2 && liftEq (liftEq f) xs ys
 
+-- | A value type, with abstractions indicated by the type argument. In pretty
+-- much any case imaginable, this would be either 'AbstractTy' (in the ASG) or
+-- 'Renamed' (after renaming).
+--
+-- @ since 1.0.0
 data ValT (a :: Type)
-  = Abstraction a
-  | ThunkT (CompT a)
-  | BuiltinFlat BuiltinFlatT
-  | BuiltinNested (BuiltinNestedT a)
-  deriving stock (Eq, Show)
+  = -- | An abstract type.
+    Abstraction a
+  | -- | A suspended computation.
+    ThunkT (CompT a)
+  | -- | A builtin type without any nesting.
+    BuiltinFlat BuiltinFlatT
+  | -- | A builtin type which is \'nested\'; something like lists, pairs etc.
+    BuiltinNested (BuiltinNestedT a)
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
 
+-- Note (Koz, 04/03/2025): We use this for testing to compare for structural
+-- similarity.
 instance Eq1 ValT where
   {-# INLINEABLE liftEq #-}
   liftEq f = \case
@@ -59,6 +135,8 @@ instance Eq1 ValT where
       BuiltinNested t2 -> liftEq f t1 t2
       _ -> False
 
+-- | All builtin types that are \'flat\': that is, do not have other types
+-- \'nested inside them\'.
 data BuiltinFlatT
   = UnitT
   | BoolT
@@ -69,13 +147,37 @@ data BuiltinFlatT
   | BLS12_381_G2_ElementT
   | BLS12_381_MlResultT
   | DataT
-  deriving stock (Eq, Show)
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
 
+-- | Builtin types which have \'nested\' types. This is currently lists and
+-- pairs only.
+--
+-- = Important note
+--
+-- Both \'arms\' of this type have \'type abstraction boundaries\' just before
+-- them: their first field indicates how many type variables they bind.
+--
+-- While in truth, these types aren't /really/ polymorphic (as they cannot hold
+-- thunks, for example), we define them this way for now.
+--
+-- @since 1.0.0
 data BuiltinNestedT (a :: Type)
-  = ListT Word8 (ValT a)
-  | PairT Word8 (ValT a) (ValT a)
-  deriving stock (Eq, Show)
+  = ListT Word64 (ValT a)
+  | PairT Word64 (ValT a) (ValT a)
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
 
+-- Note (Koz, 04/03/2025): We use this for testing to compare for structural
+-- similarity.
 instance Eq1 BuiltinNestedT where
   {-# INLINEABLE liftEq #-}
   liftEq f = \case
@@ -86,12 +188,44 @@ instance Eq1 BuiltinNestedT where
       PairT abses2 t21 t22 -> abses1 == abses2 && liftEq f t11 t21 && liftEq f t12 t22
       _ -> False
 
-newtype RenameM (a :: Type) = RenameM (RWS Int () (Word64, Bimap (Int, Word8) Word64) a)
-  deriving (Functor, Applicative, Monad) via (RWS Int () (Word64, Bimap (Int, Word8) Word64))
+-- | A \'renaming monad\' which allows us to convert type representations from
+-- ones that use /relative/ abstraction labelling to /absolute/ abstraction
+-- labelling.
+--
+-- = Why this is necessary
+--
+-- Consider the following 'AbstractTy': @'BoundAtScope' 1 0@. The meaning of
+-- this is relative to where in a type it is positioned: it could be bound by a
+-- scope higher than our own, or something we can unify with. Because its
+-- meaning (namely, what it refers to) is situational, type checking becomes
+-- more difficult, although it has other advantages.
+--
+-- This monad allows us to convert this relative form into an absolute one. More
+-- specifically, the renamer does two things:
+--
+-- * Ensures that any given abstraction refers to one, and /only/ one, thing;
+-- and
+-- * Indicates which abstractions are unifiable, and which are (effectively)
+-- constant or fixed.
+--
+-- @since 1.0.0
+newtype RenameM (a :: Type) = RenameM (RWS Int () (Word64, Bimap (Int, Word64) Word64) a)
+  deriving
+    ( -- | @since 1.0.0
+      Functor,
+      -- | @since 1.0.0
+      Applicative,
+      -- | @since 1.0.0
+      Monad
+    )
+    via (RWS Int () (Word64, Bimap (Int, Word64) Word64))
 
+-- Increase the scope by one level.
 stepDown :: forall (a :: Type). RenameM a -> RenameM a
 stepDown (RenameM comp) = RenameM (local (+ 1) comp)
 
+-- Given an abstraction in relative form, transform it into an abstraction in
+-- absolute form.
 renameAbstraction :: AbstractTy -> RenameM Renamed
 renameAbstraction absTy = RenameM $ do
   currLevel <- ask
@@ -125,12 +259,20 @@ renameAbstraction absTy = RenameM $ do
               pure . Can'tSet $ renaming
             Just renameIx -> pure . Can'tSet $ renameIx
 
+-- | Run a renaming computation, while also producing the mapping of any fixed
+-- abstractions to their original (non-relative) scope and position.
+--
+-- @since 1.0.0
 runRenameM ::
   forall (a :: Type).
-  RenameM a -> (Bimap (Int, Word8) Word64, a)
+  RenameM a -> (Bimap (Int, Word64) Word64, a)
 runRenameM (RenameM comp) = case runRWS comp 0 (0, Bimap.empty) of
   (res, (_, tracker), ()) -> (tracker, res)
 
+-- | Given a value type with relative abstractions, produce the same value type,
+-- but with absolute abstractions.
+--
+-- @since 1.0.0
 renameValT :: ValT AbstractTy -> RenameM (ValT Renamed)
 renameValT = \case
   Abstraction absTy -> Abstraction <$> renameAbstraction absTy
@@ -146,147 +288,8 @@ renameValT = \case
           <$> stepDown (renameValT t1)
           <*> stepDown (renameValT t2)
 
+-- | As 'renameValT', but for computation types.
+--
+-- @since 1.0.0
 renameCompT :: CompT AbstractTy -> RenameM (CompT Renamed)
 renameCompT (CompT abses xs) = CompT abses <$> stepDown (traverse renameValT xs)
-
-{-
-data TypeApplyError
-  = ExcessArgs [ValT]
-  | InsufficientArgs (NonEmpty ValT)
-  | IrrelevantTyVar Word8
-  | CouldNotUnify ValT ValT
-
-applyArgs :: CompT -> [ValT] -> Either TypeApplyError ValT
-applyArgs (CompT comp) args = fmap fst . evalRWST (go comp args) 0 $ Map.empty
-  where
-    go :: NonEmpty ValT -> [ValT] -> RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ValT
-    go = \case
-      res :| [] -> \case
-        [] -> resolveResult res
-        args' -> throwError . ExcessArgs $ args'
-      required@(curr :| (rest : rests)) -> \case
-        [] -> throwError . InsufficientArgs $ required
-        arg : args' -> unify curr arg >> go (rest :| rests) args'
-
-resolveResult :: ValT -> RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ValT
-resolveResult = \case
-  absT@(AbsT scope ix) -> do
-    level <- ask
-    if scope == level
-      then
-        gets (Map.lookup ix) >>= \case
-          Nothing -> throwError . IrrelevantTyVar $ ix
-          Just t -> pure t
-      else pure absT -- Not ours, so nothing we can really do here
-  ThunkT (CompT comp) -> ThunkT . CompT <$> local (+ 1) (traverse resolveResult comp)
-  BuiltinFlat t -> pure $ BuiltinFlat t -- nothing to resolve, we're concrete
-  BuiltinNested t ->
-    local
-      (+ 1)
-      ( BuiltinNested <$> case t of
-          ListT t' -> ListT <$> local (+ 1) (resolveResult t')
-          PairT t1 t2 -> PairT <$> local (+ 1) (resolveResult t1) <*> local (+ 1) (resolveResult t2)
-      )
-
-unify :: ValT -> ValT -> RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ()
-unify lhs rhs = case lhs of
-  BuiltinFlat t1 -> case rhs of
-    BuiltinFlat t2 -> unless (t1 == t2) failToUnify
-    AbsT scope ix -> do
-      level <- ask
-      if scope == level
-        then
-          gets (Map.lookup ix) >>= \case
-            -- We've never seen this tyvar before, and it's our choice
-            -- Set it to match lhs and move on
-            -- We can do this safely without cycle-checking because we couldn't
-            -- possibly break anything with such an assignment
-            Nothing -> modify (Map.insert ix lhs)
-            Just t -> unify lhs t
-        else failToUnify
-    _ -> throwError . CouldNotUnify lhs $ rhs
-  ThunkT compT1 -> case rhs of
-    ThunkT compT2 -> _
-    AbsT scope ix -> _
-    _ -> failToUnify
-  BuiltinNested t1 -> case rhs of
-    BuiltinNested t2 -> case t1 of
-      ListT t1' -> local (+ 1) $ case t2 of
-        ListT t2' -> local (+ 1) $ unify t1' t2'
-        _ -> failToUnify
-      PairT t11 t12 -> local (+ 1) $ case t2 of
-        PairT t21 t22 -> local (+ 1) (unify t11 t21) >> local (+ 1) (unify t21 t22)
-        _ -> failToUnify
-    AbsT scope ix -> _
-    _ -> failToUnify
-  AbsT scope1 ix1 ->
-    asks (compare scope1) >>= \case
-      -- This tyvar is abstract in a way we don't control. Thus, it matches only
-      -- itself.
-      LT -> case rhs of
-        AbsT scope2 ix2 -> unless (scope1 == scope2 && ix1 == ix2) failToUnify
-        _ -> failToUnify
-      -- This tyvar is a reference to one of our abstractions.
-      EQ ->
-        gets (Map.lookup ix1) >>= \case
-          -- We've never seen this tyvar before and it's our choice.
-          -- Becasue rhs could be anything, we have to tread carefully to avoid
-          -- accidentally forming a cycle (meaning, failing an occurs check).
-          Nothing -> _
-          -- We've seen (and defined) this before, so just try unifying with it
-          -- instead.
-          Just t -> unify t rhs
-      -- This tyvar is 'pinned' by someone above our scope. Thus, it
-      -- matches only itself.
-      GT -> case rhs of
-        AbsT scope2 ix2 -> unless (scope1 == scope2 && ix1 == ix2) failToUnify
-        _ -> failToUnify
-  where
-    failToUnify :: RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ()
-    failToUnify = throwError . CouldNotUnify lhs $ rhs
-
--- Helpers
-
--- forall a b . (a -> !b) -> [a] -> ![b]
-mapT :: CompT
-mapT = CompT $ fType :| [xsType, resultType]
-  where
-    fType :: ValT
-    fType = ThunkT (CompT $ AbsT 1 0 :| [AbsT 1 1]) -- One scope above for both, first var, then second var
-    xsType :: ValT
-    xsType = BuiltinNested . ListT $ AbsT 2 0 -- Two scopes above, first var
-    resultType :: ValT
-    resultType = BuiltinNested . ListT $ AbsT 2 1 -- Two scopes above, second var
-
--- forall a b . a -> b -> !a
-const2T :: CompT
-const2T = CompT $ AbsT 0 0 :| [AbsT 0 1, AbsT 0 0]
-
--- forall a . a -> !(forall b . b -> !a)
-const1T :: CompT
-const1T = CompT $ AbsT 0 0 :| [ThunkT . CompT $ AbsT 0 0 :| [AbsT 1 0]]
-
--- forall a . [a]
-faListOuter :: ValT
-faListOuter = BuiltinNested . ListT $ AbsT 1 0 -- 1 scope out, first variable
-
--- [forall a . a]
-faListInner :: ValT
-faListInner = BuiltinNested . ListT $ AbsT 0 0 -- our scope, first variable
-
--- forall a b . (a, b)
-pairOuter :: ValT
-pairOuter = BuiltinNested . PairT (AbsT 1 0) $ AbsT 1 1
-
--- forall a . (a, forall b . b)
-pairRInner :: ValT
-pairRInner = BuiltinNested . PairT (AbsT 1 0) $ AbsT 0 0
-
--- forall b . (forall a . a, b)
-pairLInner :: ValT
-pairLInner = BuiltinNested . PairT (AbsT 0 0) $ AbsT 1 0
-
--- (forall a . a, forall b . b)
-pairInner :: ValT
-pairInner = BuiltinNested . PairT (AbsT 0 0) $ AbsT 0 0
--}

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -1,0 +1,292 @@
+module Covenant.Type
+  ( AbstractTy (..),
+    Renamed (..),
+    CompT (..),
+    ValT (..),
+    BuiltinFlatT (..),
+    BuiltinNestedT (..),
+    renameValT,
+    renameCompT,
+    RenameM,
+    runRenameM,
+  )
+where
+
+import Control.Monad.Reader (ask, local)
+import Control.Monad.State.Strict (gets, modify)
+import Control.Monad.Trans.RWS.CPS (RWS, runRWS)
+import Data.Bimap (Bimap)
+import Data.Bimap qualified as Bimap
+import Data.Functor.Classes (Eq1 (liftEq))
+import Data.Kind (Type)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Word (Word64, Word8)
+
+data AbstractTy = ForallAA | BoundAtScope Word8 Word8
+  deriving stock (Eq, Show)
+
+data Renamed = CanSet Word8 | Can'tSet Word64
+  deriving stock (Eq, Ord, Show)
+
+data CompT (a :: Type) = CompT Word8 (NonEmpty (ValT a))
+  deriving stock (Eq, Show)
+
+instance Eq1 CompT where
+  {-# INLINEABLE liftEq #-}
+  liftEq f (CompT abses1 xs) (CompT abses2 ys) =
+    abses1 == abses2 && liftEq (liftEq f) xs ys
+
+data ValT (a :: Type)
+  = Abstraction a
+  | ThunkT (CompT a)
+  | BuiltinFlat BuiltinFlatT
+  | BuiltinNested (BuiltinNestedT a)
+  deriving stock (Eq, Show)
+
+instance Eq1 ValT where
+  {-# INLINEABLE liftEq #-}
+  liftEq f = \case
+    Abstraction abs1 -> \case
+      Abstraction abs2 -> f abs1 abs2
+      _ -> False
+    ThunkT t1 -> \case
+      ThunkT t2 -> liftEq f t1 t2
+      _ -> False
+    BuiltinFlat t1 -> \case
+      BuiltinFlat t2 -> t1 == t2
+      _ -> False
+    BuiltinNested t1 -> \case
+      BuiltinNested t2 -> liftEq f t1 t2
+      _ -> False
+
+data BuiltinFlatT
+  = UnitT
+  | BoolT
+  | IntegerT
+  | StringT
+  | ByteStringT
+  | BLS12_381_G1_ElementT
+  | BLS12_381_G2_ElementT
+  | BLS12_381_MlResultT
+  | DataT
+  deriving stock (Eq, Show)
+
+data BuiltinNestedT (a :: Type)
+  = ListT Word8 (ValT a)
+  | PairT Word8 (ValT a) (ValT a)
+  deriving stock (Eq, Show)
+
+instance Eq1 BuiltinNestedT where
+  {-# INLINEABLE liftEq #-}
+  liftEq f = \case
+    ListT abses1 t1 -> \case
+      ListT abses2 t2 -> abses1 == abses2 && liftEq f t1 t2
+      _ -> False
+    PairT abses1 t11 t12 -> \case
+      PairT abses2 t21 t22 -> abses1 == abses2 && liftEq f t11 t21 && liftEq f t12 t22
+      _ -> False
+
+newtype RenameM (a :: Type) = RenameM (RWS Int () (Word64, Bimap (Int, Word8) Word64) a)
+  deriving (Functor, Applicative, Monad) via (RWS Int () (Word64, Bimap (Int, Word8) Word64))
+
+stepDown :: forall (a :: Type). RenameM a -> RenameM a
+stepDown (RenameM comp) = RenameM (local (+ 1) comp)
+
+renameAbstraction :: AbstractTy -> RenameM Renamed
+renameAbstraction absTy = RenameM $ do
+  currLevel <- ask
+  case absTy of
+    ForallAA ->
+      if currLevel == 0
+        then pure . CanSet $ 0
+        else do
+          renaming <- Can'tSet <$> gets fst
+          -- We bump the source of fresh names, but don't record an entry for
+          -- this; all such entries are completely unique, but on restoring
+          -- original names, will be the same.
+          modify $ \(source, tracker) -> (source + 1, tracker)
+          pure renaming
+    -- We need to determine the true level to see if:
+    --
+    -- 1. We can set this at all (aka, whether it's unfixed and touchable); and
+    -- 2. Whether we've seen this before.
+    BoundAtScope scope ix -> do
+      let trueLevel = currLevel - fromIntegral scope
+      if trueLevel == 0
+        then pure . CanSet $ ix
+        else do
+          -- Check if this is something we already renamed previously, and if
+          -- so, rename consistently.
+          priorRename <- gets (Bimap.lookup (trueLevel, ix) . snd)
+          case priorRename of
+            Nothing -> do
+              renaming <- gets fst
+              modify $ \(source, tracker) -> (source + 1, Bimap.insert (trueLevel, ix) renaming tracker)
+              pure . Can'tSet $ renaming
+            Just renameIx -> pure . Can'tSet $ renameIx
+
+runRenameM ::
+  forall (a :: Type).
+  RenameM a -> (Bimap (Int, Word8) Word64, a)
+runRenameM (RenameM comp) = case runRWS comp 0 (0, Bimap.empty) of
+  (res, (_, tracker), ()) -> (tracker, res)
+
+renameValT :: ValT AbstractTy -> RenameM (ValT Renamed)
+renameValT = \case
+  Abstraction absTy -> Abstraction <$> renameAbstraction absTy
+  -- We're crossing a type abstraction boundary, so bump the level
+  ThunkT t -> ThunkT <$> renameCompT t
+  BuiltinFlat t -> pure . BuiltinFlat $ t
+  BuiltinNested t ->
+    BuiltinNested <$> case t of
+      -- We're crossing a type abstraction boundary, so bump the level
+      ListT abses t' -> ListT abses <$> stepDown (renameValT t')
+      PairT abses t1 t2 ->
+        PairT abses
+          <$> stepDown (renameValT t1)
+          <*> stepDown (renameValT t2)
+
+renameCompT :: CompT AbstractTy -> RenameM (CompT Renamed)
+renameCompT (CompT abses xs) = CompT abses <$> stepDown (traverse renameValT xs)
+
+{-
+data TypeApplyError
+  = ExcessArgs [ValT]
+  | InsufficientArgs (NonEmpty ValT)
+  | IrrelevantTyVar Word8
+  | CouldNotUnify ValT ValT
+
+applyArgs :: CompT -> [ValT] -> Either TypeApplyError ValT
+applyArgs (CompT comp) args = fmap fst . evalRWST (go comp args) 0 $ Map.empty
+  where
+    go :: NonEmpty ValT -> [ValT] -> RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ValT
+    go = \case
+      res :| [] -> \case
+        [] -> resolveResult res
+        args' -> throwError . ExcessArgs $ args'
+      required@(curr :| (rest : rests)) -> \case
+        [] -> throwError . InsufficientArgs $ required
+        arg : args' -> unify curr arg >> go (rest :| rests) args'
+
+resolveResult :: ValT -> RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ValT
+resolveResult = \case
+  absT@(AbsT scope ix) -> do
+    level <- ask
+    if scope == level
+      then
+        gets (Map.lookup ix) >>= \case
+          Nothing -> throwError . IrrelevantTyVar $ ix
+          Just t -> pure t
+      else pure absT -- Not ours, so nothing we can really do here
+  ThunkT (CompT comp) -> ThunkT . CompT <$> local (+ 1) (traverse resolveResult comp)
+  BuiltinFlat t -> pure $ BuiltinFlat t -- nothing to resolve, we're concrete
+  BuiltinNested t ->
+    local
+      (+ 1)
+      ( BuiltinNested <$> case t of
+          ListT t' -> ListT <$> local (+ 1) (resolveResult t')
+          PairT t1 t2 -> PairT <$> local (+ 1) (resolveResult t1) <*> local (+ 1) (resolveResult t2)
+      )
+
+unify :: ValT -> ValT -> RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ()
+unify lhs rhs = case lhs of
+  BuiltinFlat t1 -> case rhs of
+    BuiltinFlat t2 -> unless (t1 == t2) failToUnify
+    AbsT scope ix -> do
+      level <- ask
+      if scope == level
+        then
+          gets (Map.lookup ix) >>= \case
+            -- We've never seen this tyvar before, and it's our choice
+            -- Set it to match lhs and move on
+            -- We can do this safely without cycle-checking because we couldn't
+            -- possibly break anything with such an assignment
+            Nothing -> modify (Map.insert ix lhs)
+            Just t -> unify lhs t
+        else failToUnify
+    _ -> throwError . CouldNotUnify lhs $ rhs
+  ThunkT compT1 -> case rhs of
+    ThunkT compT2 -> _
+    AbsT scope ix -> _
+    _ -> failToUnify
+  BuiltinNested t1 -> case rhs of
+    BuiltinNested t2 -> case t1 of
+      ListT t1' -> local (+ 1) $ case t2 of
+        ListT t2' -> local (+ 1) $ unify t1' t2'
+        _ -> failToUnify
+      PairT t11 t12 -> local (+ 1) $ case t2 of
+        PairT t21 t22 -> local (+ 1) (unify t11 t21) >> local (+ 1) (unify t21 t22)
+        _ -> failToUnify
+    AbsT scope ix -> _
+    _ -> failToUnify
+  AbsT scope1 ix1 ->
+    asks (compare scope1) >>= \case
+      -- This tyvar is abstract in a way we don't control. Thus, it matches only
+      -- itself.
+      LT -> case rhs of
+        AbsT scope2 ix2 -> unless (scope1 == scope2 && ix1 == ix2) failToUnify
+        _ -> failToUnify
+      -- This tyvar is a reference to one of our abstractions.
+      EQ ->
+        gets (Map.lookup ix1) >>= \case
+          -- We've never seen this tyvar before and it's our choice.
+          -- Becasue rhs could be anything, we have to tread carefully to avoid
+          -- accidentally forming a cycle (meaning, failing an occurs check).
+          Nothing -> _
+          -- We've seen (and defined) this before, so just try unifying with it
+          -- instead.
+          Just t -> unify t rhs
+      -- This tyvar is 'pinned' by someone above our scope. Thus, it
+      -- matches only itself.
+      GT -> case rhs of
+        AbsT scope2 ix2 -> unless (scope1 == scope2 && ix1 == ix2) failToUnify
+        _ -> failToUnify
+  where
+    failToUnify :: RWST Word8 () (Map Word8 ValT) (Either TypeApplyError) ()
+    failToUnify = throwError . CouldNotUnify lhs $ rhs
+
+-- Helpers
+
+-- forall a b . (a -> !b) -> [a] -> ![b]
+mapT :: CompT
+mapT = CompT $ fType :| [xsType, resultType]
+  where
+    fType :: ValT
+    fType = ThunkT (CompT $ AbsT 1 0 :| [AbsT 1 1]) -- One scope above for both, first var, then second var
+    xsType :: ValT
+    xsType = BuiltinNested . ListT $ AbsT 2 0 -- Two scopes above, first var
+    resultType :: ValT
+    resultType = BuiltinNested . ListT $ AbsT 2 1 -- Two scopes above, second var
+
+-- forall a b . a -> b -> !a
+const2T :: CompT
+const2T = CompT $ AbsT 0 0 :| [AbsT 0 1, AbsT 0 0]
+
+-- forall a . a -> !(forall b . b -> !a)
+const1T :: CompT
+const1T = CompT $ AbsT 0 0 :| [ThunkT . CompT $ AbsT 0 0 :| [AbsT 1 0]]
+
+-- forall a . [a]
+faListOuter :: ValT
+faListOuter = BuiltinNested . ListT $ AbsT 1 0 -- 1 scope out, first variable
+
+-- [forall a . a]
+faListInner :: ValT
+faListInner = BuiltinNested . ListT $ AbsT 0 0 -- our scope, first variable
+
+-- forall a b . (a, b)
+pairOuter :: ValT
+pairOuter = BuiltinNested . PairT (AbsT 1 0) $ AbsT 1 1
+
+-- forall a . (a, forall b . b)
+pairRInner :: ValT
+pairRInner = BuiltinNested . PairT (AbsT 1 0) $ AbsT 0 0
+
+-- forall b . (forall a . a, b)
+pairLInner :: ValT
+pairLInner = BuiltinNested . PairT (AbsT 0 0) $ AbsT 1 0
+
+-- (forall a . a, forall b . b)
+pairInner :: ValT
+pairInner = BuiltinNested . PairT (AbsT 0 0) $ AbsT 0 0
+-}

--- a/test/renaming/Main.hs
+++ b/test/renaming/Main.hs
@@ -1,0 +1,280 @@
+module Main (main) where
+
+import Covenant.Type
+  ( AbstractTy (BoundAtScope, ForallAA),
+    BuiltinFlatT
+      ( BLS12_381_G1_ElementT,
+        BLS12_381_G2_ElementT,
+        BLS12_381_MlResultT,
+        BoolT,
+        ByteStringT,
+        DataT,
+        IntegerT,
+        StringT,
+        UnitT
+      ),
+    BuiltinNestedT (ListT, PairT),
+    CompT (CompT),
+    Renamed (Can'tSet, CanSet),
+    ValT (Abstraction, BuiltinFlat, BuiltinNested, ThunkT),
+    renameCompT,
+    renameValT,
+    runRenameM,
+  )
+import Data.Bimap qualified as Bimap
+import Data.Coerce (coerce)
+import Data.Functor.Classes (liftEq)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty qualified as NonEmpty
+import Test.QuickCheck
+  ( Arbitrary (arbitrary, shrink),
+    Gen,
+    Property,
+    elements,
+    forAllShrinkShow,
+    listOf,
+    oneof,
+    sized,
+    (.&&.),
+    (===),
+  )
+import Test.Tasty (adjustOption, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+import Test.Tasty.QuickCheck (QuickCheckTests, testProperty)
+
+main :: IO ()
+main =
+  defaultMain . adjustOption moreTests . testGroup "Renaming" $
+    [ testCase "bare abstraction" testBareAbs,
+      testGroup
+        "Builtin flat types"
+        [ testCase "UnitT" $ testFlat UnitT,
+          testCase "BoolT" $ testFlat BoolT,
+          testCase "IntegerT" $ testFlat IntegerT,
+          testCase "StringT" $ testFlat StringT,
+          testCase "ByteStringT" $ testFlat ByteStringT,
+          testCase "G1ElementT" $ testFlat BLS12_381_G1_ElementT,
+          testCase "G2ElementT" $ testFlat BLS12_381_G2_ElementT,
+          testCase "MlResultT" $ testFlat BLS12_381_MlResultT,
+          testCase "DataT" $ testFlat DataT
+        ],
+      testProperty "Nested concrete types" propNestedConcrete,
+      testCase "Rename id type" testIdT,
+      testCase "Rename const type" testConstT,
+      testCase "Rename HeadList type" testHeadListT,
+      testCase "Rename SndPair type" testSndPairT,
+      testCase "Rename map function over lists" testMapT,
+      testGroup
+        "Nested foralls"
+        [ testCase "forall a b . (a, b)" testPairTOuterOuter,
+          testCase "forall a . (a, forall b . b)" testPairTOuterInner,
+          testCase "forall b . (forall a . a, b)" testPairTInnerOuter,
+          testCase "(forall a . a, forall b . b)" testPairTInnerInner
+        ]
+    ]
+  where
+    -- Note (Koz, 26/02/2025): By default, QuickCheck runs only 100 tests per
+    -- property, which is far to few. Using the method below, we can ensure that
+    -- we run a decent number of tests, while also permitting more than this to
+    -- be set via the CLI if we want.
+    moreTests :: QuickCheckTests -> QuickCheckTests
+    moreTests = max 10_000
+
+-- Tests and properties
+
+testBareAbs :: IO ()
+testBareAbs = do
+  let absTy = Abstraction ForallAA
+  let expected = Abstraction (CanSet 0)
+  let (tracker, actual) = runRenameM . renameValT $ absTy
+  assertEqual "" expected actual
+  let entry = Bimap.lookup (0, 0) tracker
+  assertEqual "" Nothing entry
+
+testFlat :: BuiltinFlatT -> IO ()
+testFlat t = do
+  let input = BuiltinFlat t
+  let (tracker, actual) = runRenameM . renameValT $ input
+  assertBool "" (liftEq (\_ _ -> False) input actual)
+  assertEqual "" Bimap.empty tracker
+
+propNestedConcrete :: Property
+propNestedConcrete = forAllShrinkShow arbitrary shrink show $ \(Concrete t) ->
+  let (tracker, actual) = runRenameM . renameValT $ t
+   in tracker === Bimap.empty .&&. liftEq (\_ _ -> False) t actual
+
+testIdT :: IO ()
+testIdT = do
+  let absA = BoundAtScope 1 0
+  let idT = CompT 1 $ Abstraction absA :| [Abstraction absA]
+  let expected = CompT 1 $ Abstraction (CanSet 0) :| [Abstraction (CanSet 0)]
+  let (tracker, actual) = runRenameM . renameCompT $ idT
+  assertEqual "" expected actual
+  assertEqual "" Bimap.empty tracker
+
+testConstT :: IO ()
+testConstT = do
+  let absA = BoundAtScope 1 0
+  let absB = BoundAtScope 1 1
+  let constT = CompT 2 $ Abstraction absA :| [Abstraction absB, Abstraction absA]
+  let expected = CompT 2 $ Abstraction (CanSet 0) :| [Abstraction (CanSet 1), Abstraction (CanSet 0)]
+  let (tracker, actual) = runRenameM . renameCompT $ constT
+  assertEqual "" expected actual
+  assertEqual "" Bimap.empty tracker
+
+testHeadListT :: IO ()
+testHeadListT = do
+  let absA = BoundAtScope 1 0
+  let absAInner = BoundAtScope 2 0
+  let headListT = CompT 1 $ BuiltinNested (ListT 0 (Abstraction absAInner)) :| [Abstraction absA]
+  let expected = CompT 1 $ BuiltinNested (ListT 0 (Abstraction (CanSet 0))) :| [Abstraction (CanSet 0)]
+  let (tracker, actual) = runRenameM . renameCompT $ headListT
+  assertEqual "" expected actual
+  assertEqual "" Bimap.empty tracker
+
+testSndPairT :: IO ()
+testSndPairT = do
+  let sndPairT =
+        CompT 2 $
+          BuiltinNested (PairT 0 (Abstraction (BoundAtScope 2 0)) (Abstraction (BoundAtScope 2 1)))
+            :| [Abstraction (BoundAtScope 1 1)]
+  let expected =
+        CompT 2 $
+          BuiltinNested (PairT 0 (Abstraction (CanSet 0)) (Abstraction (CanSet 1)))
+            :| [Abstraction (CanSet 1)]
+  let (tracker, actual) = runRenameM . renameCompT $ sndPairT
+  assertEqual "" expected actual
+  assertEqual "" Bimap.empty tracker
+
+testMapT :: IO ()
+testMapT = do
+  let mapThunkT = ThunkT . CompT 0 $ Abstraction (BoundAtScope 2 0) :| [Abstraction (BoundAtScope 2 1)]
+  let mapT =
+        CompT 2 $
+          mapThunkT
+            :| [ BuiltinNested (ListT 0 (Abstraction (BoundAtScope 2 0))),
+                 BuiltinNested (ListT 0 (Abstraction (BoundAtScope 2 1)))
+               ]
+  let expectedMapThunkT = ThunkT . CompT 0 $ Abstraction (Can'tSet 0) :| [Abstraction (Can'tSet 1)]
+  let expectedThunkT = ThunkT . CompT 0 $ Abstraction (CanSet 0) :| [Abstraction (CanSet 1)]
+  let expectedMapT =
+        CompT 2 $
+          expectedThunkT
+            :| [ BuiltinNested (ListT 0 (Abstraction (CanSet 0))),
+                 BuiltinNested (ListT 0 (Abstraction (CanSet 1)))
+               ]
+  let (trackerThunkT, actualThunkT) = runRenameM . renameValT $ mapThunkT
+  assertEqual "" expectedMapThunkT actualThunkT
+  let expectedThunkTracker = Bimap.fromList [((-1, 0), 0), ((-1, 1), 1)]
+  assertEqual "" expectedThunkTracker trackerThunkT
+  let (trackerMapT, actualMapT) = runRenameM . renameCompT $ mapT
+  assertEqual "" expectedMapT actualMapT
+  assertEqual "" Bimap.empty trackerMapT
+
+testPairTOuterOuter :: IO ()
+testPairTOuterOuter = do
+  let pairT =
+        BuiltinNested . PairT 2 (Abstraction (BoundAtScope 1 0)) . Abstraction . BoundAtScope 1 $ 1
+  let expected =
+        BuiltinNested . PairT 2 (Abstraction (CanSet 0)) . Abstraction . CanSet $ 1
+  let (tracker, actual) = runRenameM . renameValT $ pairT
+  assertEqual "" expected actual
+  assertEqual "" Bimap.empty tracker
+
+testPairTInnerOuter :: IO ()
+testPairTInnerOuter = do
+  let pairT =
+        BuiltinNested . PairT 1 (Abstraction ForallAA) . Abstraction . BoundAtScope 1 $ 0
+  let expected =
+        BuiltinNested . PairT 1 (Abstraction (Can'tSet 0)) . Abstraction . CanSet $ 0
+  let (tracker, actual) = runRenameM . renameValT $ pairT
+  assertEqual "" expected actual
+  assertEqual "" Bimap.empty tracker
+
+testPairTOuterInner :: IO ()
+testPairTOuterInner = do
+  let pairT =
+        BuiltinNested . PairT 1 (Abstraction (BoundAtScope 1 0)) . Abstraction $ ForallAA
+  let expected =
+        BuiltinNested . PairT 1 (Abstraction (CanSet 0)) . Abstraction . Can'tSet $ 0
+  let (tracker, actual) = runRenameM . renameValT $ pairT
+  assertEqual "" expected actual
+  assertEqual "" Bimap.empty tracker
+
+testPairTInnerInner :: IO ()
+testPairTInnerInner = do
+  let pairT =
+        BuiltinNested . PairT 0 (Abstraction ForallAA) . Abstraction $ ForallAA
+  let expected =
+        BuiltinNested . PairT 0 (Abstraction (Can'tSet 0)) . Abstraction . Can'tSet $ 1
+  let (tracker, actual) = runRenameM . renameValT $ pairT
+  assertEqual "" expected actual
+  let expectedTracker = Bimap.empty
+  assertEqual "" expectedTracker tracker
+
+-- Helpers
+
+-- A newtype wrapper which generates only 'fully concrete' ValTs
+newtype Concrete = Concrete (ValT AbstractTy)
+  deriving (Eq) via (ValT AbstractTy)
+  deriving stock (Show)
+
+instance Arbitrary Concrete where
+  {-# INLINEABLE arbitrary #-}
+  arbitrary = Concrete <$> sized go
+    where
+      go :: Int -> Gen (ValT AbstractTy)
+      go size
+        | size <= 0 =
+            BuiltinFlat
+              <$> elements
+                [ UnitT,
+                  BoolT,
+                  IntegerT,
+                  StringT,
+                  ByteStringT,
+                  BLS12_381_G1_ElementT,
+                  BLS12_381_G2_ElementT,
+                  BLS12_381_MlResultT,
+                  DataT
+                ]
+        | otherwise =
+            oneof
+              [ pure . BuiltinFlat $ UnitT,
+                pure . BuiltinFlat $ BoolT,
+                pure . BuiltinFlat $ IntegerT,
+                pure . BuiltinFlat $ StringT,
+                pure . BuiltinFlat $ ByteStringT,
+                pure . BuiltinFlat $ BLS12_381_G1_ElementT,
+                pure . BuiltinFlat $ BLS12_381_G2_ElementT,
+                pure . BuiltinFlat $ BLS12_381_MlResultT,
+                pure . BuiltinFlat $ DataT,
+                BuiltinNested . ListT 0 <$> go (size `quot` 4),
+                BuiltinNested <$> (PairT 0 <$> go (size `quot` 4) <*> go (size `quot` 4)),
+                ThunkT . CompT 0 <$> ((:|) <$> go (size `quot` 4) <*> listOf (go (size `quot` 4)))
+              ]
+  {-# INLINEABLE shrink #-}
+  shrink (Concrete v) =
+    Concrete <$> case v of
+      -- impossible
+      Abstraction _ -> []
+      ThunkT (CompT _ ts) ->
+        -- Note (Koz, 26/02/2025): This is needed because, for some weird
+        -- reason, NonEmpty lacks an Arbitrary instance.
+        ThunkT . CompT 0 <$> do
+          let asList = NonEmpty.toList ts
+          shrunk <- fmap coerce . shrink . fmap Concrete $ asList
+          case shrunk of
+            [] -> []
+            x : xs -> pure (x :| xs)
+      -- Can't shrink this
+      BuiltinFlat _ -> []
+      BuiltinNested t ->
+        BuiltinNested <$> case t of
+          ListT _ t' -> do
+            Concrete shrunk <- shrink (Concrete t')
+            pure . ListT 0 $ shrunk
+          PairT _ t1 t2 -> do
+            Concrete shrunkT1 <- shrink (Concrete t1)
+            Concrete shrunkT2 <- shrink (Concrete t2)
+            [PairT 0 shrunkT1 t2, PairT 0 t1 shrunkT2]

--- a/test/renaming/Main.hs
+++ b/test/renaming/Main.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import Covenant.DeBruijn (DeBruijn (S, Z))
-import Covenant.Index (ix0, ix1)
+import Covenant.Index (count0, count1, count2, ix0, ix1)
 import Covenant.Type
   ( AbstractTy (BoundAt),
     BuiltinFlatT
@@ -116,8 +116,14 @@ propNestedConcrete = forAllShrinkShow arbitrary shrink show $ \(Concrete t) ->
 -- Checks that `forall a . a -> !a` correctly renames.
 testIdT :: IO ()
 testIdT = do
-  let idT = CompT 1 . NonEmpty.consV (Abstraction (BoundAt Z ix0)) $ [Abstraction (BoundAt Z ix0)]
-  let expected = CompT 1 . NonEmpty.consV (Abstraction (Unifiable ix0)) $ [Abstraction (Unifiable ix0)]
+  let idT =
+        CompT count1
+          . NonEmpty.consV (Abstraction (BoundAt Z ix0))
+          $ [Abstraction (BoundAt Z ix0)]
+  let expected =
+        CompT count1
+          . NonEmpty.consV (Abstraction (Unifiable ix0))
+          $ [Abstraction (Unifiable ix0)]
   let result = runRenameM . renameCompT $ idT
   assertRight (assertEqual "" expected) result
 
@@ -126,10 +132,14 @@ testConstT :: IO ()
 testConstT = do
   let absA = BoundAt Z ix0
   let absB = BoundAt Z ix1
-  let constT = CompT 2 . NonEmpty.consV (Abstraction absA) $ [Abstraction absB, Abstraction absA]
+  let constT =
+        CompT count2
+          . NonEmpty.consV (Abstraction absA)
+          $ [Abstraction absB, Abstraction absA]
   let expected =
-        CompT 2 . NonEmpty.consV (Abstraction (Unifiable ix0)) $
-          [Abstraction (Unifiable ix1), Abstraction (Unifiable ix0)]
+        CompT count2
+          . NonEmpty.consV (Abstraction (Unifiable ix0))
+          $ [Abstraction (Unifiable ix1), Abstraction (Unifiable ix0)]
   let result = runRenameM . renameCompT $ constT
   assertRight (assertEqual "" expected) result
 
@@ -137,16 +147,16 @@ testConstT = do
 testConstT2 :: IO ()
 testConstT2 = do
   let constT =
-        CompT 1
+        CompT count1
           . NonEmpty.consV
             (Abstraction (BoundAt Z ix0))
-          $ [ ThunkT . CompT 1 . NonEmpty.consV (Abstraction (BoundAt Z ix0)) $ [Abstraction (BoundAt (S Z) ix0)]
+          $ [ ThunkT . CompT count1 . NonEmpty.consV (Abstraction (BoundAt Z ix0)) $ [Abstraction (BoundAt (S Z) ix0)]
             ]
   let expected =
-        CompT 1
+        CompT count1
           . NonEmpty.consV
             (Abstraction (Unifiable ix0))
-          $ [ ThunkT . CompT 1 . NonEmpty.consV (Abstraction (Wildcard 1 ix0)) $ [Abstraction (Unifiable ix0)]
+          $ [ ThunkT . CompT count1 . NonEmpty.consV (Abstraction (Wildcard 1 ix0)) $ [Abstraction (Unifiable ix0)]
             ]
   let result = runRenameM . renameCompT $ constT
   assertRight (assertEqual "" expected) result
@@ -157,12 +167,12 @@ testHeadListT = do
   let absA = BoundAt Z ix0
   let absAInner = BoundAt (S Z) ix0
   let headListT =
-        CompT 1
-          . NonEmpty.consV (BuiltinNested (ListT 0 (Abstraction absAInner)))
+        CompT count1
+          . NonEmpty.consV (BuiltinNested (ListT count0 (Abstraction absAInner)))
           $ [Abstraction absA]
   let expected =
-        CompT 1
-          . NonEmpty.consV (BuiltinNested (ListT 0 (Abstraction (Unifiable ix0))))
+        CompT count1
+          . NonEmpty.consV (BuiltinNested (ListT count0 (Abstraction (Unifiable ix0))))
           $ [Abstraction (Unifiable ix0)]
   let result = runRenameM . renameCompT $ headListT
   assertRight (assertEqual "" expected) result
@@ -171,14 +181,14 @@ testHeadListT = do
 testSndPairT :: IO ()
 testSndPairT = do
   let sndPairT =
-        CompT 2
+        CompT count2
           . NonEmpty.consV
-            (BuiltinNested (PairT 0 (Abstraction (BoundAt (S Z) ix0)) (Abstraction (BoundAt (S Z) ix1))))
+            (BuiltinNested (PairT count0 (Abstraction (BoundAt (S Z) ix0)) (Abstraction (BoundAt (S Z) ix1))))
           $ [Abstraction (BoundAt Z ix1)]
   let expected =
-        CompT 2
+        CompT count2
           . NonEmpty.consV
-            (BuiltinNested (PairT 0 (Abstraction (Unifiable ix0)) (Abstraction (Unifiable ix1))))
+            (BuiltinNested (PairT count0 (Abstraction (Unifiable ix0)) (Abstraction (Unifiable ix1))))
           $ [Abstraction (Unifiable ix1)]
   let result = runRenameM . renameCompT $ sndPairT
   assertRight (assertEqual "" expected) result
@@ -190,27 +200,27 @@ testMapT :: IO ()
 testMapT = do
   let mapThunkT =
         ThunkT
-          . CompT 0
+          . CompT count0
           . NonEmpty.consV (Abstraction (BoundAt (S Z) ix0))
           $ [Abstraction (BoundAt (S Z) ix1)]
   let mapT =
-        CompT 2
+        CompT count2
           . NonEmpty.consV
             mapThunkT
-          $ [ BuiltinNested (ListT 0 (Abstraction (BoundAt (S Z) ix0))),
-              BuiltinNested (ListT 0 (Abstraction (BoundAt (S Z) ix1)))
+          $ [ BuiltinNested (ListT count0 (Abstraction (BoundAt (S Z) ix0))),
+              BuiltinNested (ListT count0 (Abstraction (BoundAt (S Z) ix1)))
             ]
   let expectedMapThunkT =
         ThunkT
-          . CompT 0
+          . CompT count0
           . NonEmpty.consV (Abstraction (Rigid 0 ix0))
           $ [Abstraction (Rigid 0 ix1)]
   let expectedMapT =
-        CompT 2
+        CompT count2
           . NonEmpty.consV
-            (ThunkT . CompT 0 . NonEmpty.consV (Abstraction (Unifiable ix0)) $ [Abstraction (Unifiable ix1)])
-          $ [ BuiltinNested (ListT 0 (Abstraction (Unifiable ix0))),
-              BuiltinNested (ListT 0 (Abstraction (Unifiable ix1)))
+            (ThunkT . CompT count0 . NonEmpty.consV (Abstraction (Unifiable ix0)) $ [Abstraction (Unifiable ix1)])
+          $ [ BuiltinNested (ListT count0 (Abstraction (Unifiable ix0))),
+              BuiltinNested (ListT count0 (Abstraction (Unifiable ix1)))
             ]
   let resultThunkT = runRenameM . renameValT $ mapThunkT
   assertRight (assertEqual "" expectedMapThunkT) resultThunkT
@@ -221,16 +231,24 @@ testMapT = do
 testPairT :: IO ()
 testPairT = do
   let pairT =
-        BuiltinNested . PairT 2 (Abstraction (BoundAt Z ix0)) . Abstraction . BoundAt Z $ ix1
+        BuiltinNested
+          . PairT count2 (Abstraction (BoundAt Z ix0))
+          . Abstraction
+          . BoundAt Z
+          $ ix1
   let expected =
-        BuiltinNested . PairT 2 (Abstraction (Unifiable ix0)) . Abstraction . Unifiable $ ix1
+        BuiltinNested
+          . PairT count2 (Abstraction (Unifiable ix0))
+          . Abstraction
+          . Unifiable
+          $ ix1
   let result = runRenameM . renameValT $ pairT
   assertRight (assertEqual "" expected) result
 
 -- Checks that `forall a b . [a]` triggers the irrelevance checker.
 testDodgyListT :: IO ()
 testDodgyListT = do
-  let listT = BuiltinNested . ListT 2 $ Abstraction (BoundAt Z ix0)
+  let listT = BuiltinNested . ListT count2 $ Abstraction (BoundAt Z ix0)
   let result = runRenameM . renameValT $ listT
   case result of
     Left IrrelevantAbstraction -> assertBool "" True
@@ -240,7 +258,10 @@ testDodgyListT = do
 -- Checks that `forall a b . a -> !a` triggers the overdeterminance checker.
 testDodgyIdT :: IO ()
 testDodgyIdT = do
-  let idT = CompT 2 . NonEmpty.consV (Abstraction (BoundAt Z ix0)) $ [Abstraction (BoundAt Z ix0)]
+  let idT =
+        CompT count2
+          . NonEmpty.consV (Abstraction (BoundAt Z ix0))
+          $ [Abstraction (BoundAt Z ix0)]
   let result = runRenameM . renameCompT $ idT
   case result of
     Left OverdeterminateAbstraction -> assertBool "" True
@@ -251,8 +272,8 @@ testDodgyIdT = do
 testDodgyConstT :: IO ()
 testDodgyConstT = do
   let constT =
-        CompT 2 . NonEmpty.consV (Abstraction (BoundAt Z ix0)) $
-          [ ThunkT (CompT 0 . NonEmpty.consV (Abstraction (BoundAt (S Z) ix1)) $ [Abstraction (BoundAt (S Z) ix0)])
+        CompT count2 . NonEmpty.consV (Abstraction (BoundAt Z ix0)) $
+          [ ThunkT (CompT count0 . NonEmpty.consV (Abstraction (BoundAt (S Z) ix1)) $ [Abstraction (BoundAt (S Z) ix0)])
           ]
   let result = runRenameM . renameCompT $ constT
   case result of
@@ -263,7 +284,10 @@ testDodgyConstT = do
 -- Checks that `forall a . b -> !a` triggers the variable indexing checker.
 testIndexingIdT :: IO ()
 testIndexingIdT = do
-  let t = CompT 1 . NonEmpty.consV (Abstraction (BoundAt Z ix0)) $ [Abstraction (BoundAt Z ix1)]
+  let t =
+        CompT count1
+          . NonEmpty.consV (Abstraction (BoundAt Z ix0))
+          $ [Abstraction (BoundAt Z ix1)]
   let result = runRenameM . renameCompT $ t
   case result of
     Left (InvalidAbstractionReference trueLevel ix) -> do
@@ -318,9 +342,9 @@ instance Arbitrary Concrete where
                 pure . BuiltinFlat $ BLS12_381_G2_ElementT,
                 pure . BuiltinFlat $ BLS12_381_MlResultT,
                 pure . BuiltinFlat $ DataT,
-                BuiltinNested . ListT 0 <$> go (size `quot` 4),
-                BuiltinNested <$> (PairT 0 <$> go (size `quot` 4) <*> go (size `quot` 4)),
-                ThunkT . CompT 0 <$> (NonEmpty.consV <$> go (size `quot` 4) <*> liftArbitrary (go (size `quot` 4)))
+                BuiltinNested . ListT count0 <$> go (size `quot` 4),
+                BuiltinNested <$> (PairT count0 <$> go (size `quot` 4) <*> go (size `quot` 4)),
+                ThunkT . CompT count0 <$> (NonEmpty.consV <$> go (size `quot` 4) <*> liftArbitrary (go (size `quot` 4)))
               ]
   {-# INLINEABLE shrink #-}
   shrink (Concrete v) =
@@ -330,7 +354,7 @@ instance Arbitrary Concrete where
       ThunkT (CompT _ ts) ->
         -- Note (Koz, 06/04/2025): This is needed because non-empty Vectors
         -- don't have Arbitrary instances.
-        ThunkT . CompT 0 <$> do
+        ThunkT . CompT count0 <$> do
           let asList = NonEmpty.toList ts
           shrunk <- fmap coerce . shrink . fmap Concrete $ asList
           case shrunk of
@@ -342,8 +366,8 @@ instance Arbitrary Concrete where
         BuiltinNested <$> case t of
           ListT _ t' -> do
             Concrete shrunk <- shrink (Concrete t')
-            pure . ListT 0 $ shrunk
+            pure . ListT count0 $ shrunk
           PairT _ t1 t2 -> do
             Concrete shrunkT1 <- shrink (Concrete t1)
             Concrete shrunkT2 <- shrink (Concrete t2)
-            [PairT 0 shrunkT1 t2, PairT 0 t1 shrunkT2]
+            [PairT count0 shrunkT1 t2, PairT count0 t1 shrunkT2]


### PR DESCRIPTION
Partially-addresses #9 and #41 . This produces a basic implementation of a CBPV type system with polymorphism, analogous to System F. To assist in hash consing, we use a similar DeBruijn-like system for type abstractions, but extend it to allow us to have 'denser' levels than a single variable at a time. We also provide a renamer, allowing us to 'fix' the abstractions in a way that makes type checking and other manipulations easier.

We also provide some tests to ensure the renamer works as we expect. 