### PR TITLE
Types for primops, remove MkNil and MkNilPair, tests

### DIFF
--- a/covenant.cabal
+++ b/covenant.cabal
@@ -137,4 +137,11 @@ test-suite renaming
 
   hs-source-dirs: test/renaming
 
+test-suite primops
+  import: test-lang
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  build-depends: nonempty-vector
+  hs-source-dirs: test/primops
+
 -- Benchmarks

--- a/src/Covenant/Internal/PrimType.hs
+++ b/src/Covenant/Internal/PrimType.hs
@@ -45,8 +45,6 @@ import Covenant.Prim
         LengthOfByteString,
         ListData,
         MapData,
-        MkNilData,
-        MkNilPairData,
         NullList,
         Ripemd_160,
         SerialiseData,
@@ -147,8 +145,6 @@ typeOfOneArgFunc =
     UnIData -> (TyPlutusData, TyInteger)
     UnBData -> (TyPlutusData, TyByteString)
     SerialiseData -> (TyPlutusData, TyByteString)
-    MkNilData -> (TyUnit, TyList TyPlutusData)
-    MkNilPairData -> (TyUnit, TyList (TyPair TyPlutusData TyPlutusData))
     BLS12_381_G1_neg -> (TyBLS12_381G1Element, TyBLS12_381G1Element)
     BLS12_381_G1_compress -> (TyBLS12_381G1Element, TyByteString)
     BLS12_381_G1_uncompress -> (TyByteString, TyBLS12_381G1Element)

--- a/src/Covenant/Prim.hs
+++ b/src/Covenant/Prim.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 -- |
 -- Module: Covenant.Prim
 -- Copyright: (C) MLabs 2025
@@ -10,15 +12,58 @@
 -- @since 1.0.0
 module Covenant.Prim
   ( OneArgFunc (..),
+    typeOneArgFunc,
     TwoArgFunc (..),
+    typeTwoArgFunc,
     ThreeArgFunc (..),
+    typeThreeArgFunc,
     SixArgFunc (..),
+    typeSixArgFunc,
   )
 where
 
+import Covenant.DeBruijn (DeBruijn (S, Z))
+import Covenant.Index (count0, ix0, ix1)
+import Covenant.Type
+  ( AbstractTy,
+    CompT (CompT),
+    ValT (ThunkT),
+    boolT,
+    byteStringT,
+    comp0,
+    comp1,
+    comp2,
+    dataT,
+    g1T,
+    g2T,
+    integerT,
+    listT,
+    mlResultT,
+    stringT,
+    tyvar,
+    unitT,
+    (-*-),
+    pattern ReturnT,
+    pattern (:--:>),
+  )
 import Test.QuickCheck (Arbitrary (arbitrary), elements)
 
 -- | All one-argument primitives provided by Plutus.
+--
+-- = Note
+--
+-- We exclude the @MkNilData@ and @MkNilPairData@ primitives from this list for
+-- several reasons. For clarity, we list these below. Firstly, the reason why
+-- these primitives still exist at all is historical: Plutus now has the ability
+-- to directly \'lift\' empty list constants into itself. Secondly, while these
+-- primitives /could/ still be used instead of direct lifts, there is never a
+-- reason to prefer them, as they are less efficient than embedding a constant
+-- directly. Thirdly, their naive typings would end up with overdetermined type
+-- variables - consider the typing of @MkNilData@:
+--
+-- @forall a . () -> ![a]@
+--
+-- For all of these reasons, we do not represent these primitives in the ASG.
 --
 -- @since 1.0.0
 data OneArgFunc
@@ -43,8 +88,6 @@ data OneArgFunc
   | UnIData
   | UnBData
   | SerialiseData
-  | MkNilData
-  | MkNilPairData
   | BLS12_381_G1_neg
   | BLS12_381_G1_compress
   | BLS12_381_G1_uncompress
@@ -94,8 +137,6 @@ instance Arbitrary OneArgFunc where
         UnIData,
         UnBData,
         SerialiseData,
-        MkNilData,
-        MkNilPairData,
         BLS12_381_G1_neg,
         BLS12_381_G1_compress,
         BLS12_381_G1_uncompress,
@@ -109,6 +150,62 @@ instance Arbitrary OneArgFunc where
         FindFirstSetBit,
         Ripemd_160
       ]
+
+-- | Produce the type of a single-argument primop.
+--
+-- @since 1.0.0
+typeOneArgFunc :: OneArgFunc -> CompT AbstractTy
+typeOneArgFunc = \case
+  LengthOfByteString -> comp0 $ byteStringT :--:> ReturnT integerT
+  Sha2_256 -> hashingT
+  Sha3_256 -> hashingT
+  Blake2b_256 -> hashingT
+  EncodeUtf8 -> comp0 $ stringT :--:> ReturnT byteStringT
+  DecodeUtf8 -> comp0 $ byteStringT :--:> ReturnT stringT
+  FstPair ->
+    comp2 $
+      (tyvar (S Z) ix0 -*- tyvar (S Z) ix1)
+        :--:> ReturnT (tyvar Z ix0)
+  SndPair ->
+    comp2 $
+      (tyvar (S Z) ix0 -*- tyvar (S Z) ix1)
+        :--:> ReturnT (tyvar Z ix1)
+  HeadList ->
+    comp1 $ list0 (tyvar (S Z) ix0) :--:> ReturnT (tyvar Z ix0)
+  TailList ->
+    comp1 $
+      list0 (tyvar (S Z) ix0)
+        :--:> ReturnT (listT count0 (tyvar (S Z) ix0))
+  NullList ->
+    comp1 $ list0 (tyvar (S Z) ix0) :--:> ReturnT boolT
+  MapData ->
+    comp0 $ list0 (dataT -*- dataT) :--:> ReturnT dataT
+  ListData -> comp0 $ list0 dataT :--:> ReturnT dataT
+  IData -> comp0 $ integerT :--:> ReturnT dataT
+  BData -> comp0 $ byteStringT :--:> ReturnT dataT
+  UnConstrData -> comp0 $ dataT :--:> ReturnT (integerT -*- list0 dataT)
+  UnMapData -> comp0 $ dataT :--:> ReturnT (list0 (dataT -*- dataT))
+  UnListData -> comp0 $ dataT :--:> ReturnT (list0 dataT)
+  UnIData -> comp0 $ dataT :--:> ReturnT integerT
+  UnBData -> comp0 $ dataT :--:> ReturnT byteStringT
+  SerialiseData -> comp0 $ dataT :--:> ReturnT byteStringT
+  BLS12_381_G1_neg -> comp0 $ g1T :--:> ReturnT g1T
+  BLS12_381_G1_compress -> comp0 $ g1T :--:> ReturnT byteStringT
+  BLS12_381_G1_uncompress -> comp0 $ byteStringT :--:> ReturnT g1T
+  BLS12_381_G2_neg -> comp0 $ g2T :--:> ReturnT g2T
+  BLS12_381_G2_compress -> comp0 $ g2T :--:> ReturnT byteStringT
+  BLS12_381_G2_uncompress -> comp0 $ byteStringT :--:> ReturnT g2T
+  Keccak_256 -> hashingT
+  Blake2b_244 -> hashingT
+  ComplementByteString -> comp0 $ byteStringT :--:> ReturnT byteStringT
+  CountSetBits -> comp0 $ byteStringT :--:> ReturnT integerT
+  FindFirstSetBit -> comp0 $ byteStringT :--:> ReturnT integerT
+  Ripemd_160 -> hashingT
+  where
+    list0 :: ValT AbstractTy -> ValT AbstractTy
+    list0 = listT count0
+    hashingT :: CompT AbstractTy
+    hashingT = CompT count0 $ byteStringT :--:> ReturnT byteStringT
 
 -- | All two-argument primitives provided by Plutus.
 --
@@ -212,6 +309,61 @@ instance Arbitrary TwoArgFunc where
         RotateByteString
       ]
 
+-- | Produce the type of a two-argument primop.
+--
+-- @since 1.0.0
+typeTwoArgFunc :: TwoArgFunc -> CompT AbstractTy
+typeTwoArgFunc = \case
+  AddInteger -> combineT integerT
+  SubtractInteger -> combineT integerT
+  MultiplyInteger -> combineT integerT
+  DivideInteger -> combineT integerT
+  QuotientInteger -> combineT integerT
+  RemainderInteger -> combineT integerT
+  ModInteger -> combineT integerT
+  EqualsInteger -> compareT integerT
+  LessThanInteger -> compareT integerT
+  LessThanEqualsInteger -> compareT integerT
+  AppendByteString -> combineT byteStringT
+  ConsByteString -> comp0 $ integerT :--:> byteStringT :--:> ReturnT byteStringT
+  IndexByteString -> comp0 $ byteStringT :--:> integerT :--:> ReturnT integerT
+  EqualsByteString -> compareT byteStringT
+  LessThanByteString -> compareT byteStringT
+  LessThanEqualsByteString -> compareT byteStringT
+  AppendString -> combineT stringT
+  EqualsString -> compareT stringT
+  ChooseUnit -> comp1 $ unitT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
+  Trace -> comp1 $ stringT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
+  MkCons ->
+    comp1 $
+      tyvar Z ix0
+        :--:> listT count0 (tyvar (S Z) ix0)
+        :--:> ReturnT (tyvar Z ix0)
+  ConstrData -> comp0 $ integerT :--:> listT count0 dataT :--:> ReturnT dataT
+  EqualsData -> compareT dataT
+  MkPairData -> comp0 $ dataT :--:> dataT :--:> ReturnT (dataT -*- dataT)
+  BLS12_381_G1_add -> combineT g1T
+  BLS12_381_G1_scalarMul -> comp0 $ integerT :--:> g1T :--:> ReturnT g1T
+  BLS12_381_G1_equal -> compareT g1T
+  BLS12_381_G1_hashToGroup -> comp0 $ byteStringT :--:> byteStringT :--:> ReturnT g1T
+  BLS12_381_G2_add -> combineT g2T
+  BLS12_381_G2_scalarMul -> comp0 $ integerT :--:> g2T :--:> ReturnT g2T
+  BLS12_381_G2_equal -> compareT g2T
+  BLS12_381_G2_hashToGroup -> comp0 $ byteStringT :--:> byteStringT :--:> ReturnT g2T
+  BLS12_381_millerLoop -> comp0 $ g1T :--:> g2T :--:> ReturnT mlResultT
+  BLS12_381_mulMlResult -> combineT mlResultT
+  BLS12_381_finalVerify -> comp0 $ mlResultT :--:> mlResultT :--:> ReturnT boolT
+  ByteStringToInteger -> comp0 $ boolT :--:> byteStringT :--:> ReturnT integerT
+  ReadBit -> comp0 $ byteStringT :--:> integerT :--:> ReturnT boolT
+  ReplicateByte -> comp0 $ integerT :--:> integerT :--:> ReturnT byteStringT
+  ShiftByteString -> comp0 $ byteStringT :--:> integerT :--:> ReturnT byteStringT
+  RotateByteString -> comp0 $ byteStringT :--:> integerT :--:> ReturnT byteStringT
+  where
+    combineT :: ValT AbstractTy -> CompT AbstractTy
+    combineT t = comp0 $ t :--:> t :--:> ReturnT t
+    compareT :: ValT AbstractTy -> CompT AbstractTy
+    compareT t = comp0 $ t :--:> t :--:> ReturnT boolT
+
 -- | All three-argument primitives provided by Plutus.
 --
 -- @since 1.0.0
@@ -258,6 +410,71 @@ instance Arbitrary ThreeArgFunc where
         ExpModInteger
       ]
 
+-- | Produce the type of a three-argument primop.
+--
+-- @since 1.0.0
+typeThreeArgFunc :: ThreeArgFunc -> CompT AbstractTy
+typeThreeArgFunc = \case
+  VerifyEd25519Signature -> signatureT
+  VerifyEcdsaSecp256k1Signature -> signatureT
+  VerifySchnorrSecp256k1Signature -> signatureT
+  IfThenElse ->
+    comp1 $
+      boolT
+        :--:> tyvar Z ix0
+        :--:> tyvar Z ix0
+        :--:> ReturnT (tyvar Z ix0)
+  ChooseList ->
+    comp2 $
+      listT count0 (tyvar (S Z) ix0)
+        :--:> tyvar Z ix1
+        :--:> tyvar Z ix1
+        :--:> ReturnT (tyvar Z ix1)
+  CaseList ->
+    comp2 $
+      tyvar Z ix1
+        :--:> ThunkT
+          ( comp0 $
+              tyvar (S Z) ix0
+                :--:> listT count0 (tyvar (S (S Z)) ix0)
+                :--:> ReturnT (tyvar (S Z) ix1)
+          )
+        :--:> listT count0 (tyvar (S Z) ix0)
+        :--:> ReturnT (tyvar Z ix1)
+  IntegerToByteString ->
+    comp0 $
+      boolT :--:> integerT :--:> integerT :--:> ReturnT byteStringT
+  AndByteString -> bitwiseT
+  OrByteString -> bitwiseT
+  XorByteString -> bitwiseT
+  WriteBits ->
+    comp0 $
+      byteStringT
+        :--:> listT count0 integerT
+        :--:> boolT
+        :--:> ReturnT byteStringT
+  ExpModInteger ->
+    comp0 $
+      integerT
+        :--:> integerT
+        :--:> integerT
+        :--:> ReturnT integerT
+  where
+    signatureT :: CompT AbstractTy
+    signatureT =
+      comp0 $
+        byteStringT
+          :--:> byteStringT
+          :--:> byteStringT
+          :--:> ReturnT boolT
+    bitwiseT :: CompT AbstractTy
+    bitwiseT =
+      comp0 $
+        boolT
+          :--:> byteStringT
+          :--:> byteStringT
+          :--:> ReturnT byteStringT
+
 -- | All six-argument primitives provided by Plutus.
 --
 -- @since 1.0.0
@@ -279,3 +496,27 @@ data SixArgFunc
 instance Arbitrary SixArgFunc where
   {-# INLINEABLE arbitrary #-}
   arbitrary = elements [ChooseData, CaseData]
+
+-- | Produce the type of a six-argument primop.
+--
+-- @since 1.0.0
+typeSixArgFunc :: SixArgFunc -> CompT AbstractTy
+typeSixArgFunc = \case
+  ChooseData ->
+    comp1 $
+      dataT
+        :--:> tyvar Z ix0
+        :--:> tyvar Z ix0
+        :--:> tyvar Z ix0
+        :--:> tyvar Z ix0
+        :--:> tyvar Z ix0
+        :--:> ReturnT (tyvar Z ix0)
+  CaseData ->
+    comp1 $
+      ThunkT (comp0 $ integerT :--:> listT count0 dataT :--:> ReturnT (tyvar (S Z) ix0))
+        :--:> ThunkT (comp0 $ listT count0 (dataT -*- dataT) :--:> ReturnT (tyvar (S Z) ix0))
+        :--:> ThunkT (comp0 $ listT count0 dataT :--:> ReturnT (tyvar (S Z) ix0))
+        :--:> ThunkT (comp0 $ integerT :--:> ReturnT (tyvar (S Z) ix0))
+        :--:> ThunkT (comp0 $ byteStringT :--:> ReturnT (tyvar (S Z) ix0))
+        :--:> dataT
+        :--:> ReturnT (tyvar Z ix0)

--- a/src/Covenant/Prim.hs
+++ b/src/Covenant/Prim.hs
@@ -338,7 +338,7 @@ typeTwoArgFunc = \case
     comp1 $
       tyvar Z ix0
         :--:> listT count0 (tyvar (S Z) ix0)
-        :--:> ReturnT (tyvar Z ix0)
+        :--:> ReturnT (listT count0 (tyvar (S Z) ix0))
   ConstrData -> comp0 $ integerT :--:> listT count0 dataT :--:> ReturnT dataT
   EqualsData -> compareT dataT
   MkPairData -> comp0 $ dataT :--:> dataT :--:> ReturnT (dataT -*- dataT)

--- a/test/primops/Main.hs
+++ b/test/primops/Main.hs
@@ -1,0 +1,116 @@
+module Main (main) where
+
+import Covenant.Prim
+  ( typeOneArgFunc,
+    typeSixArgFunc,
+    typeThreeArgFunc,
+    typeTwoArgFunc,
+  )
+import Covenant.Type
+  ( AbstractTy (BoundAt),
+    CompT (CompT),
+    Renamed (Unifiable),
+    renameCompT,
+    runRenameM,
+  )
+import Data.Functor.Classes (liftEq)
+import Data.Kind (Type)
+import Data.Vector.NonEmpty qualified as NonEmpty
+import Test.QuickCheck
+  ( Property,
+    arbitrary,
+    counterexample,
+    forAll,
+    property,
+    (===),
+  )
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+main :: IO ()
+main =
+  defaultMain . testGroup "Primops" $
+    [ -- Since there are so few primops, we don't increase the test count
+      -- beyond the default 100, as it would just be redundant.
+      testGroup
+        "Arity"
+        [ testProperty "One-argument primops take one argument" prop1Arg,
+          testProperty "Two-argument primops take two arguments" prop2Args,
+          testProperty "Three-argument primops take three arguments" prop3Args,
+          testProperty "Six-argument primops take six arguments" prop6Args
+        ],
+      testGroup
+        "Renaming"
+        [ testProperty "One-argument primops rename correctly" prop1Rename,
+          testProperty "Two-argument primops rename correctly" prop2Rename,
+          testProperty "Three-argument primops rename correctly" prop3Rename,
+          testProperty "Six-argument primops rename correctly" prop6Rename
+        ]
+    ]
+
+-- Test cases and properties
+
+prop1Arg :: Property
+prop1Arg = forAll arbitrary $ \oneArg ->
+  let t = typeOneArgFunc oneArg
+   in arity t === 1
+
+prop1Rename :: Property
+prop1Rename = forAll arbitrary $ \oneArg ->
+  let t = typeOneArgFunc oneArg
+      result = runRenameM . renameCompT $ t
+   in case result of
+        Left err -> counterexample (show err) False
+        Right renamed -> property $ liftEq eqRenamedVar t renamed
+
+prop2Args :: Property
+prop2Args = forAll arbitrary $ \twoArg ->
+  let t = typeTwoArgFunc twoArg
+   in arity t === 2
+
+prop2Rename :: Property
+prop2Rename = forAll arbitrary $ \twoArg ->
+  let t = typeTwoArgFunc twoArg
+      result = runRenameM . renameCompT $ t
+   in case result of
+        Left err -> counterexample (show err) False
+        Right renamed -> property $ liftEq eqRenamedVar t renamed
+
+prop3Args :: Property
+prop3Args = forAll arbitrary $ \threeArg ->
+  let t = typeThreeArgFunc threeArg
+   in arity t === 3
+
+prop3Rename :: Property
+prop3Rename = forAll arbitrary $ \threeArg ->
+  let t = typeThreeArgFunc threeArg
+      result = runRenameM . renameCompT $ t
+   in case result of
+        Left err -> counterexample (show err) False
+        Right renamed -> property $ liftEq eqRenamedVar t renamed
+
+prop6Args :: Property
+prop6Args = forAll arbitrary $ \sixArg ->
+  let t = typeSixArgFunc sixArg
+   in arity t === 6
+
+prop6Rename :: Property
+prop6Rename = forAll arbitrary $ \sixArg ->
+  let t = typeSixArgFunc sixArg
+      result = runRenameM . renameCompT $ t
+   in case result of
+        Left err -> counterexample (show err) False
+        Right renamed -> property $ liftEq eqRenamedVar t renamed
+
+-- Helpers
+
+arity :: forall (a :: Type). CompT a -> Int
+arity (CompT _ xs) = NonEmpty.length xs - 1
+
+-- In our context, the _only_ variables we have are unifiable. If we see
+-- anything else, we know we've messed up somewhere. Furthermore, the indexes
+-- should 'line up'.
+eqRenamedVar :: AbstractTy -> Renamed -> Bool
+eqRenamedVar (BoundAt _ ix) = \case
+  Unifiable ix' -> ix == ix'
+  _ -> False


### PR DESCRIPTION
Another stepping stone for #9 . This PR does the following:

* All primops now have new-style CBPV types
* Tests to ensure that these types have appropriate arities and type variables (which is about all we can automatically test)

Furthermore, we have dropped `MkNilData` and `MkNilPairData`, because they're not particularly useful. The code generator would never want to generate them anyway, they only exist for historical reasons, and allowing them to be used at all is a footgun we can easily avoid.