### PR TITLE
Cull all nested types

### DIFF
--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -109,7 +109,7 @@ import Covenant.Internal.ASGNode
     Arg (Arg),
     Bound (Bound),
     Id,
-    PrimCall (PrimCallOne, PrimCallSix, PrimCallThree, PrimCallTwo),
+    PrimCall (PrimCallOne, PrimCallThree, PrimCallTwo),
     Ref (ABound, AnArg, AnId),
     TyASGNode (ATyLam),
     TyLam (TyLam),
@@ -122,7 +122,7 @@ import Covenant.Internal.ASGNode
     pattern Lit,
     pattern Prim,
   )
-import Covenant.Internal.PrimType (typeOfOneArgFunc, typeOfSixArgFunc, typeOfThreeArgFunc, typeOfTwoArgFunc)
+import Covenant.Internal.PrimType (typeOfOneArgFunc, typeOfThreeArgFunc, typeOfTwoArgFunc)
 import Covenant.Internal.TyExpr
   ( TyExpr
       ( TyBoolean,
@@ -136,7 +136,7 @@ import Covenant.Internal.TyExpr
       ),
   )
 import Covenant.Ledger (LedgerAccessor, LedgerDestructor)
-import Covenant.Prim (OneArgFunc, SixArgFunc, ThreeArgFunc, TwoArgFunc)
+import Covenant.Prim (OneArgFunc, ThreeArgFunc, TwoArgFunc)
 import Data.Foldable (traverse_)
 import Data.Kind (Type)
 import Data.Monoid (Endo (Endo))
@@ -378,14 +378,17 @@ typePrim p = case p of
     ty2 <- typeOfRef arg2
     ty3 <- typeOfRef arg3
     liftTypeError $ typeThreeArgFunc fun ty1 ty2 ty3
-  (PrimCallSix fun arg1 arg2 arg3 arg4 arg5 arg6) -> do
-    ty1 <- typeOfRef arg1
-    ty2 <- typeOfRef arg2
-    ty3 <- typeOfRef arg3
-    ty4 <- typeOfRef arg4
-    ty5 <- typeOfRef arg5
-    ty6 <- typeOfRef arg6
-    liftTypeError $ typeSixArgFunc fun ty1 ty2 ty3 ty4 ty5 ty6
+
+{-
+(PrimCallSix fun arg1 arg2 arg3 arg4 arg5 arg6) -> do
+  ty1 <- typeOfRef arg1
+  ty2 <- typeOfRef arg2
+  ty3 <- typeOfRef arg3
+  ty4 <- typeOfRef arg4
+  ty5 <- typeOfRef arg5
+  ty6 <- typeOfRef arg6
+  liftTypeError $ typeSixArgFunc fun ty1 ty2 ty3 ty4 ty5 ty6
+-}
 
 typeOneArgFunc :: OneArgFunc -> TyASGNode -> Either TypeError TyASGNode
 typeOneArgFunc fun tyArg1 =
@@ -408,6 +411,7 @@ typeThreeArgFunc fun tyArg1 tyArg2 tyArg3 =
         then Right tyRes
         else Left $ TyErrPrimArgMismatch (Vector.fromList [tyParam1, tyParam2, tyParam3]) (Vector.fromList [tyArg1, tyArg2, tyArg3])
 
+{-
 typeSixArgFunc :: SixArgFunc -> TyASGNode -> TyASGNode -> TyASGNode -> TyASGNode -> TyASGNode -> TyASGNode -> Either TypeError TyASGNode
 typeSixArgFunc fun tyArg1 tyArg2 tyArg3 tyArg4 tyArg5 tyArg6 =
   let (tyParam1, tyParam2, tyParam3, tyParam4, tyParam5, tyParam6, tyRes) = typeOfSixArgFunc fun
@@ -418,6 +422,7 @@ typeSixArgFunc fun tyArg1 tyArg2 tyArg3 tyArg4 tyArg5 tyArg6 =
             TyErrPrimArgMismatch
               (Vector.fromList [tyParam1, tyParam2, tyParam3, tyParam4, tyParam5, tyParam6])
               (Vector.fromList [tyArg1, tyArg2, tyArg3, tyArg4, tyArg5, tyArg6])
+-}
 
 -- | Construct a ledger type accessor.
 --

--- a/src/Covenant/Internal/ASGNode.hs
+++ b/src/Covenant/Internal/ASGNode.hs
@@ -26,7 +26,7 @@ import Control.Monad.HashCons (MonadHashCons, lookupRef)
 import Covenant.Constant (AConstant)
 import Covenant.Internal.TyExpr (TyExpr)
 import Covenant.Ledger (LedgerAccessor, LedgerDestructor)
-import Covenant.Prim (OneArgFunc, SixArgFunc, ThreeArgFunc, TwoArgFunc)
+import Covenant.Prim (OneArgFunc, ThreeArgFunc, TwoArgFunc)
 import Data.Kind (Type)
 import Data.Maybe (fromJust, mapMaybe)
 import Data.Word (Word64)
@@ -103,7 +103,7 @@ data PrimCall
   = PrimCallOne OneArgFunc Ref
   | PrimCallTwo TwoArgFunc Ref Ref
   | PrimCallThree ThreeArgFunc Ref Ref Ref
-  | PrimCallSix SixArgFunc Ref Ref Ref Ref Ref Ref
+  --   | PrimCallSix SixArgFunc Ref Ref Ref Ref Ref Ref
   deriving stock
     ( -- | @since 1.0.0
       Eq,
@@ -227,7 +227,7 @@ childIds = \case
     PrimCallOne _ r1 -> mapMaybe refToId [r1]
     PrimCallTwo _ r1 r2 -> mapMaybe refToId [r1, r2]
     PrimCallThree _ r1 r2 r3 -> mapMaybe refToId [r1, r2, r3]
-    PrimCallSix _ r1 r2 r3 r4 r5 r6 -> mapMaybe refToId [r1, r2, r3, r4, r5, r6]
+  -- PrimCallSix _ r1 r2 r3 r4 r5 r6 -> mapMaybe refToId [r1, r2, r3, r4, r5, r6]
   LamInternal _ r1 -> mapMaybe refToId [r1]
   LetInternal _ r1 r2 -> mapMaybe refToId [r1, r2]
   AppInternal _ r1 r2 -> mapMaybe refToId [r1, r2]

--- a/src/Covenant/Internal/PrimType.hs
+++ b/src/Covenant/Internal/PrimType.hs
@@ -2,11 +2,11 @@ module Covenant.Internal.PrimType
   ( typeOfOneArgFunc,
     typeOfTwoArgFunc,
     typeOfThreeArgFunc,
-    typeOfSixArgFunc,
+    -- typeOfSixArgFunc,
   )
 where
 
-import Covenant.Internal.ASGNode (TyASGNode (ATyExpr, ATyLam), TyLam (TyLam))
+import Covenant.Internal.ASGNode (TyASGNode (ATyExpr))
 import Covenant.Internal.TyExpr
   ( TyExpr
       ( TyBLS12_381G1Element,
@@ -15,8 +15,6 @@ import Covenant.Internal.TyExpr
         TyBoolean,
         TyByteString,
         TyInteger,
-        TyList,
-        TyPair,
         TyPlutusData,
         TyString,
         TyUnit
@@ -24,7 +22,7 @@ import Covenant.Internal.TyExpr
   )
 import Covenant.Prim
   ( OneArgFunc
-      ( BData,
+      ( -- BData,
         BLS12_381_G1_compress,
         BLS12_381_G1_neg,
         BLS12_381_G1_uncompress,
@@ -38,31 +36,31 @@ import Covenant.Prim
         DecodeUtf8,
         EncodeUtf8,
         FindFirstSetBit,
-        FstPair,
-        HeadList,
-        IData,
+        -- FstPair,
+        -- HeadList,
+        -- IData,
         Keccak_256,
         LengthOfByteString,
-        ListData,
-        MapData,
-        NullList,
+        -- ListData,
+        -- MapData,
+        -- NullList,
         Ripemd_160,
-        SerialiseData,
+        -- SerialiseData,
         Sha2_256,
-        Sha3_256,
-        SndPair,
-        TailList,
-        UnBData,
-        UnConstrData,
-        UnIData,
-        UnListData,
-        UnMapData
+        Sha3_256
+        -- SndPair,
+        -- TailList,
+        -- UnBData,
+        -- UnConstrData,
+        -- UnIData,
+        -- UnListData,
+        -- UnMapData
       ),
-    SixArgFunc (CaseData, ChooseData),
+    -- SixArgFunc (CaseData, ChooseData),
     ThreeArgFunc
       ( AndByteString,
-        CaseList,
-        ChooseList,
+        -- CaseList,
+        -- ChooseList,
         ExpModInteger,
         IfThenElse,
         IntegerToByteString,
@@ -70,7 +68,7 @@ import Covenant.Prim
         VerifyEcdsaSecp256k1Signature,
         VerifyEd25519Signature,
         VerifySchnorrSecp256k1Signature,
-        WriteBits,
+        -- WriteBits,
         XorByteString
       ),
     TwoArgFunc
@@ -91,10 +89,10 @@ import Covenant.Prim
         ByteStringToInteger,
         ChooseUnit,
         ConsByteString,
-        ConstrData,
+        -- ConstrData,
         DivideInteger,
         EqualsByteString,
-        EqualsData,
+        -- EqualsData,
         EqualsInteger,
         EqualsString,
         IndexByteString,
@@ -102,8 +100,8 @@ import Covenant.Prim
         LessThanEqualsByteString,
         LessThanEqualsInteger,
         LessThanInteger,
-        MkCons,
-        MkPairData,
+        -- MkCons,
+        -- MkPairData,
         ModInteger,
         MultiplyInteger,
         QuotientInteger,
@@ -130,21 +128,21 @@ typeOfOneArgFunc =
     Blake2b_256 -> (TyByteString, TyByteString)
     EncodeUtf8 -> (TyString, TyByteString)
     DecodeUtf8 -> (TyByteString, TyString)
-    FstPair -> (TyPair TyPlutusData TyPlutusData, TyPlutusData)
-    SndPair -> (TyPair TyPlutusData TyPlutusData, TyPlutusData)
-    HeadList -> (TyList TyPlutusData, TyPlutusData)
-    TailList -> (TyList TyPlutusData, TyList TyPlutusData)
-    NullList -> (TyList TyPlutusData, TyBoolean)
-    MapData -> (TyList (TyPair TyPlutusData TyPlutusData), TyPlutusData)
-    ListData -> (TyList TyPlutusData, TyPlutusData)
-    IData -> (TyInteger, TyPlutusData)
-    BData -> (TyByteString, TyPlutusData)
-    UnConstrData -> (TyPlutusData, TyPair TyInteger (TyList TyPlutusData))
-    UnMapData -> (TyPlutusData, TyList (TyPair TyPlutusData TyPlutusData))
-    UnListData -> (TyPlutusData, TyList TyPlutusData)
-    UnIData -> (TyPlutusData, TyInteger)
-    UnBData -> (TyPlutusData, TyByteString)
-    SerialiseData -> (TyPlutusData, TyByteString)
+    -- FstPair -> (TyPair TyPlutusData TyPlutusData, TyPlutusData)
+    -- SndPair -> (TyPair TyPlutusData TyPlutusData, TyPlutusData)
+    -- HeadList -> (TyList TyPlutusData, TyPlutusData)
+    -- TailList -> (TyList TyPlutusData, TyList TyPlutusData)
+    -- NullList -> (TyList TyPlutusData, TyBoolean)
+    -- MapData -> (TyList (TyPair TyPlutusData TyPlutusData), TyPlutusData)
+    -- ListData -> (TyList TyPlutusData, TyPlutusData)
+    -- IData -> (TyInteger, TyPlutusData)
+    -- BData -> (TyByteString, TyPlutusData)
+    -- UnConstrData -> (TyPlutusData, TyPair TyInteger (TyList TyPlutusData))
+    -- UnMapData -> (TyPlutusData, TyList (TyPair TyPlutusData TyPlutusData))
+    -- UnListData -> (TyPlutusData, TyList TyPlutusData)
+    -- UnIData -> (TyPlutusData, TyInteger)
+    -- UnBData -> (TyPlutusData, TyByteString)
+    -- SerialiseData -> (TyPlutusData, TyByteString)
     BLS12_381_G1_neg -> (TyBLS12_381G1Element, TyBLS12_381G1Element)
     BLS12_381_G1_compress -> (TyBLS12_381G1Element, TyByteString)
     BLS12_381_G1_uncompress -> (TyByteString, TyBLS12_381G1Element)
@@ -188,10 +186,10 @@ typeOfTwoArgFunc =
     EqualsString -> (TyString, TyString, TyBoolean)
     ChooseUnit -> (TyUnit, TyPlutusData, TyPlutusData)
     Trace -> (TyString, TyPlutusData, TyPlutusData)
-    MkCons -> (TyPlutusData, TyList TyPlutusData, TyList TyPlutusData)
-    ConstrData -> (TyInteger, TyList TyPlutusData, TyPlutusData)
-    EqualsData -> (TyPlutusData, TyPlutusData, TyBoolean)
-    MkPairData -> (TyPlutusData, TyPlutusData, TyPair TyPlutusData TyPlutusData)
+    -- MkCons -> (TyPlutusData, TyList TyPlutusData, TyList TyPlutusData)
+    -- ConstrData -> (TyInteger, TyList TyPlutusData, TyPlutusData)
+    -- EqualsData -> (TyPlutusData, TyPlutusData, TyBoolean)
+    -- MkPairData -> (TyPlutusData, TyPlutusData, TyPair TyPlutusData TyPlutusData)
     BLS12_381_G1_add -> (TyBLS12_381G1Element, TyBLS12_381G1Element, TyBLS12_381G1Element)
     BLS12_381_G1_scalarMul -> (TyInteger, TyBLS12_381G1Element, TyBLS12_381G1Element)
     BLS12_381_G1_equal -> (TyBLS12_381G1Element, TyBLS12_381G1Element, TyBoolean)
@@ -223,18 +221,19 @@ typeOfThreeArgFunc =
     VerifyEcdsaSecp256k1Signature -> (TyByteString, TyByteString, TyByteString, TyBoolean)
     VerifySchnorrSecp256k1Signature -> (TyByteString, TyByteString, TyByteString, TyBoolean)
     IfThenElse -> (TyBoolean, TyPlutusData, TyPlutusData, TyPlutusData)
-    ChooseList -> (TyList TyPlutusData, TyPlutusData, TyPlutusData, TyPlutusData)
-    CaseList -> (TyList TyPlutusData, TyPlutusData, TyPair TyPlutusData (TyList TyPlutusData), TyPlutusData)
+    -- ChooseList -> (TyList TyPlutusData, TyPlutusData, TyPlutusData, TyPlutusData)
+    -- CaseList -> (TyList TyPlutusData, TyPlutusData, TyPair TyPlutusData (TyList TyPlutusData), TyPlutusData)
     IntegerToByteString -> (TyBoolean, TyInteger, TyInteger, TyByteString)
     AndByteString -> (TyBoolean, TyByteString, TyByteString, TyByteString)
     OrByteString -> (TyBoolean, TyByteString, TyByteString, TyByteString)
     XorByteString -> (TyBoolean, TyByteString, TyByteString, TyByteString)
-    WriteBits -> (TyByteString, TyList TyInteger, TyBoolean, TyByteString)
+    -- WriteBits -> (TyByteString, TyList TyInteger, TyBoolean, TyByteString)
     ExpModInteger -> (TyInteger, TyInteger, TyInteger, TyInteger)
   where
     liftTy :: (TyExpr, TyExpr, TyExpr, TyExpr) -> (TyASGNode, TyASGNode, TyASGNode, TyASGNode)
     liftTy (t1, t2, t3, t4) = (ATyExpr t1, ATyExpr t2, ATyExpr t3, ATyExpr t4)
 
+{-
 -- | Maps six-argument functions to their input and output types.
 -- Returns a tuple of (arg1 type, arg2 type, arg3 type, .. arg6 type, return type).
 --
@@ -269,3 +268,4 @@ typeOfSixArgFunc = \case
       -- a
       ATyExpr TyUnit
     )
+  -}

--- a/src/Covenant/Prim.hs
+++ b/src/Covenant/Prim.hs
@@ -17,32 +17,28 @@ module Covenant.Prim
     typeTwoArgFunc,
     ThreeArgFunc (..),
     typeThreeArgFunc,
-    SixArgFunc (..),
-    typeSixArgFunc,
+    -- SixArgFunc (..),
+    -- typeSixArgFunc,
   )
 where
 
-import Covenant.DeBruijn (DeBruijn (S, Z))
-import Covenant.Index (count0, ix0, ix1)
+import Covenant.DeBruijn (DeBruijn (Z))
+import Covenant.Index (count0, ix0)
 import Covenant.Type
   ( AbstractTy,
     CompT (CompT),
-    ValT (ThunkT),
+    ValT,
     boolT,
     byteStringT,
     comp0,
     comp1,
-    comp2,
-    dataT,
     g1T,
     g2T,
     integerT,
-    listT,
     mlResultT,
     stringT,
     tyvar,
     unitT,
-    (-*-),
     pattern ReturnT,
     pattern (:--:>),
   )
@@ -73,22 +69,22 @@ data OneArgFunc
   | Blake2b_256
   | EncodeUtf8
   | DecodeUtf8
-  | FstPair
-  | SndPair
-  | HeadList
-  | TailList
-  | NullList
-  | MapData
-  | ListData
-  | IData
-  | BData
-  | UnConstrData
-  | UnMapData
-  | UnListData
-  | UnIData
-  | UnBData
-  | SerialiseData
-  | BLS12_381_G1_neg
+  | --  | FstPair
+    --  |  SndPair
+    --  | HeadList
+    --  | TailList
+    --  | NullList
+    --  | MapData
+    --  | ListData
+    --  | IData
+    --  | BData
+    --  | UnConstrData
+    --  | UnMapData
+    --  | UnListData
+    --  | UnIData
+    --  | UnBData
+    --  | SerialiseData
+    BLS12_381_G1_neg
   | BLS12_381_G1_compress
   | BLS12_381_G1_uncompress
   | BLS12_381_G2_neg
@@ -122,21 +118,21 @@ instance Arbitrary OneArgFunc where
         Blake2b_256,
         EncodeUtf8,
         DecodeUtf8,
-        FstPair,
-        SndPair,
-        HeadList,
-        TailList,
-        NullList,
-        MapData,
-        ListData,
-        IData,
-        BData,
-        UnConstrData,
-        UnMapData,
-        UnListData,
-        UnIData,
-        UnBData,
-        SerialiseData,
+        -- FstPair,
+        -- SndPair,
+        -- HeadList,
+        -- TailList,
+        -- NullList,
+        -- MapData,
+        -- ListData,
+        -- IData,
+        -- BData,
+        -- UnConstrData,
+        -- UnMapData,
+        -- UnListData,
+        -- UnIData,
+        -- UnBData,
+        -- SerialiseData,
         BLS12_381_G1_neg,
         BLS12_381_G1_compress,
         BLS12_381_G1_uncompress,
@@ -162,33 +158,6 @@ typeOneArgFunc = \case
   Blake2b_256 -> hashingT
   EncodeUtf8 -> comp0 $ stringT :--:> ReturnT byteStringT
   DecodeUtf8 -> comp0 $ byteStringT :--:> ReturnT stringT
-  FstPair ->
-    comp2 $
-      (tyvar Z ix0 -*- tyvar Z ix1)
-        :--:> ReturnT (tyvar Z ix0)
-  SndPair ->
-    comp2 $
-      (tyvar Z ix0 -*- tyvar Z ix1)
-        :--:> ReturnT (tyvar Z ix1)
-  HeadList ->
-    comp1 $ list0 (tyvar (S Z) ix0) :--:> ReturnT (tyvar Z ix0)
-  TailList ->
-    comp1 $
-      list0 (tyvar (S Z) ix0)
-        :--:> ReturnT (listT count0 (tyvar (S Z) ix0))
-  NullList ->
-    comp1 $ list0 (tyvar (S Z) ix0) :--:> ReturnT boolT
-  MapData ->
-    comp0 $ list0 (dataT -*- dataT) :--:> ReturnT dataT
-  ListData -> comp0 $ list0 dataT :--:> ReturnT dataT
-  IData -> comp0 $ integerT :--:> ReturnT dataT
-  BData -> comp0 $ byteStringT :--:> ReturnT dataT
-  UnConstrData -> comp0 $ dataT :--:> ReturnT (integerT -*- list0 dataT)
-  UnMapData -> comp0 $ dataT :--:> ReturnT (list0 (dataT -*- dataT))
-  UnListData -> comp0 $ dataT :--:> ReturnT (list0 dataT)
-  UnIData -> comp0 $ dataT :--:> ReturnT integerT
-  UnBData -> comp0 $ dataT :--:> ReturnT byteStringT
-  SerialiseData -> comp0 $ dataT :--:> ReturnT byteStringT
   BLS12_381_G1_neg -> comp0 $ g1T :--:> ReturnT g1T
   BLS12_381_G1_compress -> comp0 $ g1T :--:> ReturnT byteStringT
   BLS12_381_G1_uncompress -> comp0 $ byteStringT :--:> ReturnT g1T
@@ -202,8 +171,6 @@ typeOneArgFunc = \case
   FindFirstSetBit -> comp0 $ byteStringT :--:> ReturnT integerT
   Ripemd_160 -> hashingT
   where
-    list0 :: ValT AbstractTy -> ValT AbstractTy
-    list0 = listT count0
     hashingT :: CompT AbstractTy
     hashingT = CompT count0 $ byteStringT :--:> ReturnT byteStringT
 
@@ -231,11 +198,11 @@ data TwoArgFunc
   | EqualsString
   | ChooseUnit
   | Trace
-  | MkCons
-  | ConstrData
-  | EqualsData
-  | MkPairData
-  | BLS12_381_G1_add
+  | -- | MkCons
+    -- | ConstrData
+    -- | EqualsData
+    -- | MkPairData
+    BLS12_381_G1_add
   | BLS12_381_G1_scalarMul
   | BLS12_381_G1_equal
   | BLS12_381_G1_hashToGroup
@@ -287,10 +254,10 @@ instance Arbitrary TwoArgFunc where
         EqualsString,
         ChooseUnit,
         Trace,
-        MkCons,
-        ConstrData,
-        EqualsData,
-        MkPairData,
+        -- MkCons,
+        -- ConstrData,
+        -- EqualsData,
+        -- MkPairData,
         BLS12_381_G1_add,
         BLS12_381_G1_scalarMul,
         BLS12_381_G1_equal,
@@ -334,14 +301,6 @@ typeTwoArgFunc = \case
   EqualsString -> compareT stringT
   ChooseUnit -> comp1 $ unitT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
   Trace -> comp1 $ stringT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
-  MkCons ->
-    comp1 $
-      tyvar Z ix0
-        :--:> listT count0 (tyvar (S Z) ix0)
-        :--:> ReturnT (listT count0 (tyvar (S Z) ix0))
-  ConstrData -> comp0 $ integerT :--:> listT count0 dataT :--:> ReturnT dataT
-  EqualsData -> compareT dataT
-  MkPairData -> comp0 $ dataT :--:> dataT :--:> ReturnT (dataT -*- dataT)
   BLS12_381_G1_add -> combineT g1T
   BLS12_381_G1_scalarMul -> comp0 $ integerT :--:> g1T :--:> ReturnT g1T
   BLS12_381_G1_equal -> compareT g1T
@@ -372,14 +331,14 @@ data ThreeArgFunc
   | VerifyEcdsaSecp256k1Signature
   | VerifySchnorrSecp256k1Signature
   | IfThenElse
-  | ChooseList
-  | CaseList
-  | IntegerToByteString
+  | -- | ChooseList
+    -- | CaseList
+    IntegerToByteString
   | AndByteString
   | OrByteString
   | XorByteString
-  | WriteBits
-  | ExpModInteger
+  | -- | WriteBits
+    ExpModInteger
   deriving stock
     ( -- | @since 1.0.0
       Eq,
@@ -400,13 +359,13 @@ instance Arbitrary ThreeArgFunc where
         VerifyEcdsaSecp256k1Signature,
         VerifySchnorrSecp256k1Signature,
         IfThenElse,
-        ChooseList,
-        CaseList,
+        -- ChooseList,
+        -- CaseList,
         IntegerToByteString,
         AndByteString,
         OrByteString,
         XorByteString,
-        WriteBits,
+        -- WriteBits,
         ExpModInteger
       ]
 
@@ -424,35 +383,12 @@ typeThreeArgFunc = \case
         :--:> tyvar Z ix0
         :--:> tyvar Z ix0
         :--:> ReturnT (tyvar Z ix0)
-  ChooseList ->
-    comp2 $
-      listT count0 (tyvar (S Z) ix0)
-        :--:> tyvar Z ix1
-        :--:> tyvar Z ix1
-        :--:> ReturnT (tyvar Z ix1)
-  CaseList ->
-    comp2 $
-      tyvar Z ix1
-        :--:> ThunkT
-          ( comp0 $
-              tyvar (S Z) ix0
-                :--:> listT count0 (tyvar (S (S Z)) ix0)
-                :--:> ReturnT (tyvar (S Z) ix1)
-          )
-        :--:> listT count0 (tyvar (S Z) ix0)
-        :--:> ReturnT (tyvar Z ix1)
   IntegerToByteString ->
     comp0 $
       boolT :--:> integerT :--:> integerT :--:> ReturnT byteStringT
   AndByteString -> bitwiseT
   OrByteString -> bitwiseT
   XorByteString -> bitwiseT
-  WriteBits ->
-    comp0 $
-      byteStringT
-        :--:> listT count0 integerT
-        :--:> boolT
-        :--:> ReturnT byteStringT
   ExpModInteger ->
     comp0 $
       integerT
@@ -475,6 +411,7 @@ typeThreeArgFunc = \case
           :--:> byteStringT
           :--:> ReturnT byteStringT
 
+{-
 -- | All six-argument primitives provided by Plutus.
 --
 -- @since 1.0.0
@@ -496,27 +433,4 @@ data SixArgFunc
 instance Arbitrary SixArgFunc where
   {-# INLINEABLE arbitrary #-}
   arbitrary = elements [ChooseData, CaseData]
-
--- | Produce the type of a six-argument primop.
---
--- @since 1.0.0
-typeSixArgFunc :: SixArgFunc -> CompT AbstractTy
-typeSixArgFunc = \case
-  ChooseData ->
-    comp1 $
-      dataT
-        :--:> tyvar Z ix0
-        :--:> tyvar Z ix0
-        :--:> tyvar Z ix0
-        :--:> tyvar Z ix0
-        :--:> tyvar Z ix0
-        :--:> ReturnT (tyvar Z ix0)
-  CaseData ->
-    comp1 $
-      ThunkT (comp0 $ integerT :--:> listT count0 dataT :--:> ReturnT (tyvar (S Z) ix0))
-        :--:> ThunkT (comp0 $ listT count0 (dataT -*- dataT) :--:> ReturnT (tyvar (S Z) ix0))
-        :--:> ThunkT (comp0 $ listT count0 dataT :--:> ReturnT (tyvar (S Z) ix0))
-        :--:> ThunkT (comp0 $ integerT :--:> ReturnT (tyvar (S Z) ix0))
-        :--:> ThunkT (comp0 $ byteStringT :--:> ReturnT (tyvar (S Z) ix0))
-        :--:> dataT
-        :--:> ReturnT (tyvar Z ix0)
+-}

--- a/test/primops/Main.hs
+++ b/test/primops/Main.hs
@@ -2,7 +2,6 @@ module Main (main) where
 
 import Covenant.Prim
   ( typeOneArgFunc,
-    typeSixArgFunc,
     typeThreeArgFunc,
     typeTwoArgFunc,
   )
@@ -36,15 +35,15 @@ main =
         "Arity"
         [ testProperty "One-argument primops take one argument" prop1Arg,
           testProperty "Two-argument primops take two arguments" prop2Args,
-          testProperty "Three-argument primops take three arguments" prop3Args,
-          testProperty "Six-argument primops take six arguments" prop6Args
+          testProperty "Three-argument primops take three arguments" prop3Args
+          --         testProperty "Six-argument primops take six arguments" prop6Args
         ],
       testGroup
         "Renaming"
         [ testProperty "One-argument primops rename correctly" prop1Rename,
           testProperty "Two-argument primops rename correctly" prop2Rename,
-          testProperty "Three-argument primops rename correctly" prop3Rename,
-          testProperty "Six-argument primops rename correctly" prop6Rename
+          testProperty "Three-argument primops rename correctly" prop3Rename
+          -- testProperty "Six-argument primops rename correctly" prop6Rename
         ]
     ]
 
@@ -68,11 +67,13 @@ prop3Args = mkArgProp typeThreeArgFunc 3
 prop3Rename :: Property
 prop3Rename = mkRenameProp typeThreeArgFunc
 
+{-
 prop6Args :: Property
 prop6Args = mkArgProp typeSixArgFunc 6
 
 prop6Rename :: Property
 prop6Rename = mkRenameProp typeSixArgFunc
+-}
 
 -- Helpers
 


### PR DESCRIPTION
This eliminates all non-flat types from the type system. Specifically, `Data`, as well as builtin lists and pairs, will be treated the same way as other user-defined or ledger data types.

Some of the relevant parts (such as primops and definitions) have been commented out, rather than fully deleted. This ensures we remember to put them back afterwards in Milestone 2. Tests have been culled down appropriately.