### PR TITLE
Better API for types

### DIFF
--- a/covenant.cabal
+++ b/covenant.cabal
@@ -98,6 +98,7 @@ library
     Covenant.Prim
     Covenant.Test
     Covenant.Type
+    Covenant.Util
 
   other-modules:
     Covenant.Internal.ASG

--- a/src/Covenant/Internal/Rename.hs
+++ b/src/Covenant/Internal/Rename.hs
@@ -24,6 +24,7 @@ import Covenant.Index (Count, Index, intCount, intIndex)
 import Covenant.Internal.Type
   ( AbstractTy (BoundAt),
     CompT (CompT),
+    CompTInternal (CompTInternal),
     Renamed (Rigid, Unifiable, Wildcard),
     ValT (Abstraction, BuiltinFlat, ThunkT),
   )
@@ -167,7 +168,7 @@ runRenameM (RenameM comp) = evalState (runExceptT comp) . RenameState 0 $ Vector
 --
 -- @since 1.0.0
 renameCompT :: CompT AbstractTy -> RenameM (CompT Renamed)
-renameCompT (CompT abses xs) = RenameM $ do
+renameCompT (CompT abses (CompTInternal xs)) = RenameM $ do
   -- Step up a scope
   modify (stepUpScope abses)
   -- Rename, but only the arguments
@@ -183,7 +184,7 @@ renameCompT (CompT abses xs) = RenameM $ do
   -- Roll back state
   modify dropDownScope
   -- Rebuild and return
-  pure . CompT abses . NonEmpty.snocV renamedArgs $ renamedResult
+  pure . CompT abses . CompTInternal . NonEmpty.snocV renamedArgs $ renamedResult
 
 -- | Rename a value type.
 --

--- a/src/Covenant/Internal/Rename.hs
+++ b/src/Covenant/Internal/Rename.hs
@@ -24,7 +24,7 @@ import Covenant.Index (Count, Index, intCount, intIndex)
 import Covenant.Internal.Type
   ( AbstractTy (BoundAt),
     CompT (CompT),
-    CompTInternal (CompTInternal),
+    CompTBody (CompTBody),
     Renamed (Rigid, Unifiable, Wildcard),
     ValT (Abstraction, BuiltinFlat, ThunkT),
   )
@@ -168,7 +168,7 @@ runRenameM (RenameM comp) = evalState (runExceptT comp) . RenameState 0 $ Vector
 --
 -- @since 1.0.0
 renameCompT :: CompT AbstractTy -> RenameM (CompT Renamed)
-renameCompT (CompT abses (CompTInternal xs)) = RenameM $ do
+renameCompT (CompT abses (CompTBody xs)) = RenameM $ do
   -- Step up a scope
   modify (stepUpScope abses)
   -- Rename, but only the arguments
@@ -184,7 +184,7 @@ renameCompT (CompT abses (CompTInternal xs)) = RenameM $ do
   -- Roll back state
   modify dropDownScope
   -- Rebuild and return
-  pure . CompT abses . CompTInternal . NonEmpty.snocV renamedArgs $ renamedResult
+  pure . CompT abses . CompTBody . NonEmpty.snocV renamedArgs $ renamedResult
 
 -- | Rename a value type.
 --

--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -2,6 +2,7 @@ module Covenant.Internal.Type
   ( AbstractTy (..),
     Renamed (..),
     CompT (..),
+    CompTInternal (..),
     ValT (..),
     BuiltinFlatT (..),
   )
@@ -14,7 +15,12 @@ import Control.Monad.Reader
     runReader,
   )
 import Covenant.DeBruijn (DeBruijn)
-import Covenant.Index (Count, Index, intCount, intIndex)
+import Covenant.Index
+  ( Count,
+    Index,
+    intCount,
+    intIndex,
+  )
 import Data.Functor.Classes (Eq1 (liftEq))
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
@@ -94,6 +100,21 @@ data Renamed
       Show
     )
 
+-- | @since 1.0.0
+newtype CompTInternal (a :: Type) = CompTInternal (NonEmptyVector (ValT a))
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
+
+-- | @since 1.0.0
+instance Eq1 CompTInternal where
+  {-# INLINEABLE liftEq #-}
+  liftEq f (CompTInternal xs) (CompTInternal ys) =
+    liftEq (liftEq f) xs ys
+
 -- | A computation type, with abstractions indicated by the type argument. In
 -- pretty much any case imaginable, this would be either 'AbstractTy' (in the
 -- ASG), or 'Renamed' (after renaming).
@@ -106,7 +127,7 @@ data Renamed
 -- The /last/ entry in the 'NonEmpty' indicates the return type.
 --
 -- @since 1.0.0
-data CompT (a :: Type) = CompT (Count "tyvar") (NonEmptyVector (ValT a))
+data CompT (a :: Type) = CompT (Count "tyvar") (CompTInternal a)
   deriving stock
     ( -- | @since 1.0.0
       Eq,
@@ -118,7 +139,7 @@ data CompT (a :: Type) = CompT (Count "tyvar") (NonEmptyVector (ValT a))
 instance Eq1 CompT where
   {-# INLINEABLE liftEq #-}
   liftEq f (CompT abses1 xs) (CompT abses2 ys) =
-    abses1 == abses2 && liftEq (liftEq f) xs ys
+    abses1 == abses2 && liftEq f xs ys
 
 -- | @since 1.0.0
 instance Pretty (CompT Renamed) where
@@ -241,7 +262,7 @@ runPrettyM (PrettyM ma) = runReader ma (PrettyContext mempty 0 infiniteVars)
        in zipWith (\x xs -> pretty (x : xs)) aToZ intStrings
 
 prettyCompTWithContext :: forall (ann :: Type). CompT Renamed -> PrettyM ann (Doc ann)
-prettyCompTWithContext (CompT count funArgs)
+prettyCompTWithContext (CompT count (CompTInternal funArgs))
   | review intCount count == 0 = prettyFunTy funArgs
   | otherwise = bindVars count $ \newVars -> do
       funTy <- prettyFunTy funArgs
@@ -301,7 +322,7 @@ isSimpleValT = \case
   _ -> True
   where
     isSimpleCompT :: CompT a -> Bool
-    isSimpleCompT (CompT count args) =
+    isSimpleCompT (CompT count (CompTInternal args)) =
       review intCount count == 0 && NonEmpty.length args == 1
 
 prettyValTWithContext :: forall (ann :: Type). ValT Renamed -> PrettyM ann (Doc ann)

--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -74,7 +74,9 @@ data AbstractTy = BoundAt DeBruijn (Index "tyvar")
       Show
     )
 
--- | @since 1.0.0
+-- | A type abstraction that has undergone renaming from a specific context.
+--
+-- @since 1.0.0
 data Renamed
   = -- | Set by an enclosing scope, and thus is essentially a
     -- concrete type, we just don't know which. First field is its \'true
@@ -100,7 +102,10 @@ data Renamed
       Show
     )
 
--- | @since 1.0.0
+-- | The \'interior\' of a computation type, consisting of the types of its
+-- arguments and the type of its result.
+--
+-- @since 1.0.0
 newtype CompTInternal (a :: Type) = CompTInternal (NonEmptyVector (ValT a))
   deriving stock
     ( -- | @since 1.0.0
@@ -123,8 +128,6 @@ instance Eq1 CompTInternal where
 --
 -- This type has a \'type abstraction boundary\' just before it: the first field
 -- indicates how many type variables it binds.
---
--- The /last/ entry in the 'NonEmpty' indicates the return type.
 --
 -- @since 1.0.0
 data CompT (a :: Type) = CompT (Count "tyvar") (CompTInternal a)
@@ -198,10 +201,10 @@ data BuiltinFlatT
 
 -- Helpers
 
--- Keeping the field names for clarity even if we don't use them
 newtype ScopeBoundary = ScopeBoundary Int
   deriving (Show, Eq, Ord, Num) via Int
 
+-- Keeping the field names for clarity even if we don't use them
 data PrettyContext (ann :: Type)
   = PrettyContext
   { _boundIdents :: Map ScopeBoundary (Vector (Doc ann)),

--- a/src/Covenant/Internal/Unification.hs
+++ b/src/Covenant/Internal/Unification.hs
@@ -16,6 +16,7 @@ import Covenant.Index (Index, intCount, intIndex)
 import Covenant.Internal.Type
   ( BuiltinFlatT,
     CompT (CompT),
+    CompTInternal (CompTInternal),
     Renamed (Rigid, Unifiable, Wildcard),
     ValT (Abstraction, BuiltinFlat, ThunkT),
   )
@@ -54,7 +55,7 @@ data TypeAppError
 
 -- | @since 1.0.0
 checkApp :: CompT Renamed -> [ValT Renamed] -> Either TypeAppError (ValT Renamed)
-checkApp (CompT _ xs) =
+checkApp (CompT _ (CompTInternal xs)) =
   let (curr, rest) = NonEmpty.uncons xs
    in go curr (Vector.toList rest)
   where
@@ -68,7 +69,7 @@ checkApp (CompT _ xs) =
         [] -> case currParam of
           Abstraction (Unifiable index) -> throwError . LeakingUnifiable $ index
           Abstraction (Wildcard scopeId index) -> throwError . LeakingWildcard scopeId $ index
-          ThunkT (CompT _ xs') -> do
+          ThunkT (CompT _ (CompTInternal xs')) -> do
             let remainingUnifiables = NonEmpty.foldl' (\acc t -> acc <> collectUnifiables t) Set.empty xs'
             let requiredIntroductions = Set.size remainingUnifiables
             -- We know that the size of a set cannot be negative, but GHC
@@ -77,7 +78,7 @@ checkApp (CompT _ xs) =
             let indexesToUse = mapMaybe (preview intIndex) [0, 1 .. requiredIntroductions - 1]
             let renames = zipWith (\i replacement -> (i, Abstraction . Unifiable $ replacement)) (Set.toList remainingUnifiables) indexesToUse
             let fixed = fmap (\t -> foldl' (\acc (i, r) -> substitute i r acc) t renames) xs'
-            pure . ThunkT . CompT asCount $ fixed
+            pure . ThunkT . CompT asCount . CompTInternal $ fixed
           _ -> pure currParam
         _ -> throwError . ExcessArgs . Vector.fromList $ args
       _ -> case args of
@@ -96,7 +97,7 @@ collectUnifiables = \case
     Unifiable index -> Set.singleton index
     _ -> Set.empty
   BuiltinFlat _ -> Set.empty
-  ThunkT (CompT _ xs) -> NonEmpty.foldl' (\acc t -> acc <> collectUnifiables t) Set.empty xs
+  ThunkT (CompT _ (CompTInternal xs)) -> NonEmpty.foldl' (\acc t -> acc <> collectUnifiables t) Set.empty xs
 
 substitute :: Index "tyvar" -> ValT Renamed -> ValT Renamed -> ValT Renamed
 substitute index toSub = \case
@@ -106,8 +107,8 @@ substitute index toSub = \case
         then toSub
         else Abstraction t
     _ -> Abstraction t
-  ThunkT (CompT abstractions xs) ->
-    ThunkT . CompT abstractions . fmap (substitute index toSub) $ xs
+  ThunkT (CompT abstractions (CompTInternal xs)) ->
+    ThunkT . CompT abstractions . CompTInternal . fmap (substitute index toSub) $ xs
   BuiltinFlat t -> BuiltinFlat t
 
 unify ::
@@ -159,10 +160,10 @@ unify expected actual =
     -- conditionally with other thunks, provided that we can unify each argument
     -- with its counterpart in the same position, as well as their result types,
     -- without conflicts.
-    expectThunk (CompT _ t1) = case actual of
+    expectThunk (CompT _ (CompTInternal t1)) = case actual of
       Abstraction (Rigid _ _) -> unificationError
       Abstraction _ -> noSubUnify
-      ThunkT (CompT _ t2) -> do
+      ThunkT (CompT _ (CompTInternal t2)) -> do
         unless (comparing NonEmpty.length t1 t2 == EQ) unificationError
         catchError
           (foldM (\acc (l, r) -> unify l r >>= reconcile acc) Map.empty . NonEmpty.zip t1 $ t2)

--- a/src/Covenant/Prim.hs
+++ b/src/Covenant/Prim.hs
@@ -25,7 +25,7 @@ import Covenant.Index (ix0)
 import Covenant.Type
   ( AbstractTy,
     CompT (Comp0, Comp1),
-    CompTInternal (ReturnT, (:--:>)),
+    CompTBody (ReturnT, (:--:>)),
     ValT,
     boolT,
     byteStringT,

--- a/src/Covenant/Prim.hs
+++ b/src/Covenant/Prim.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE PatternSynonyms #-}
-
 -- |
 -- Module: Covenant.Prim
 -- Copyright: (C) MLabs 2025
@@ -23,15 +21,14 @@ module Covenant.Prim
 where
 
 import Covenant.DeBruijn (DeBruijn (Z))
-import Covenant.Index (count0, ix0)
+import Covenant.Index (ix0)
 import Covenant.Type
   ( AbstractTy,
-    CompT (CompT),
+    CompT (Comp0, Comp1),
+    CompTInternal (ReturnT, (:--:>)),
     ValT,
     boolT,
     byteStringT,
-    comp0,
-    comp1,
     g1T,
     g2T,
     integerT,
@@ -39,8 +36,6 @@ import Covenant.Type
     stringT,
     tyvar,
     unitT,
-    pattern ReturnT,
-    pattern (:--:>),
   )
 import Test.QuickCheck (Arbitrary (arbitrary), elements)
 
@@ -152,27 +147,27 @@ instance Arbitrary OneArgFunc where
 -- @since 1.0.0
 typeOneArgFunc :: OneArgFunc -> CompT AbstractTy
 typeOneArgFunc = \case
-  LengthOfByteString -> comp0 $ byteStringT :--:> ReturnT integerT
+  LengthOfByteString -> Comp0 $ byteStringT :--:> ReturnT integerT
   Sha2_256 -> hashingT
   Sha3_256 -> hashingT
   Blake2b_256 -> hashingT
-  EncodeUtf8 -> comp0 $ stringT :--:> ReturnT byteStringT
-  DecodeUtf8 -> comp0 $ byteStringT :--:> ReturnT stringT
-  BLS12_381_G1_neg -> comp0 $ g1T :--:> ReturnT g1T
-  BLS12_381_G1_compress -> comp0 $ g1T :--:> ReturnT byteStringT
-  BLS12_381_G1_uncompress -> comp0 $ byteStringT :--:> ReturnT g1T
-  BLS12_381_G2_neg -> comp0 $ g2T :--:> ReturnT g2T
-  BLS12_381_G2_compress -> comp0 $ g2T :--:> ReturnT byteStringT
-  BLS12_381_G2_uncompress -> comp0 $ byteStringT :--:> ReturnT g2T
+  EncodeUtf8 -> Comp0 $ stringT :--:> ReturnT byteStringT
+  DecodeUtf8 -> Comp0 $ byteStringT :--:> ReturnT stringT
+  BLS12_381_G1_neg -> Comp0 $ g1T :--:> ReturnT g1T
+  BLS12_381_G1_compress -> Comp0 $ g1T :--:> ReturnT byteStringT
+  BLS12_381_G1_uncompress -> Comp0 $ byteStringT :--:> ReturnT g1T
+  BLS12_381_G2_neg -> Comp0 $ g2T :--:> ReturnT g2T
+  BLS12_381_G2_compress -> Comp0 $ g2T :--:> ReturnT byteStringT
+  BLS12_381_G2_uncompress -> Comp0 $ byteStringT :--:> ReturnT g2T
   Keccak_256 -> hashingT
   Blake2b_224 -> hashingT
-  ComplementByteString -> comp0 $ byteStringT :--:> ReturnT byteStringT
-  CountSetBits -> comp0 $ byteStringT :--:> ReturnT integerT
-  FindFirstSetBit -> comp0 $ byteStringT :--:> ReturnT integerT
+  ComplementByteString -> Comp0 $ byteStringT :--:> ReturnT byteStringT
+  CountSetBits -> Comp0 $ byteStringT :--:> ReturnT integerT
+  FindFirstSetBit -> Comp0 $ byteStringT :--:> ReturnT integerT
   Ripemd_160 -> hashingT
   where
     hashingT :: CompT AbstractTy
-    hashingT = CompT count0 $ byteStringT :--:> ReturnT byteStringT
+    hashingT = Comp0 $ byteStringT :--:> ReturnT byteStringT
 
 -- | All two-argument primitives provided by Plutus.
 --
@@ -292,36 +287,36 @@ typeTwoArgFunc = \case
   LessThanInteger -> compareT integerT
   LessThanEqualsInteger -> compareT integerT
   AppendByteString -> combineT byteStringT
-  ConsByteString -> comp0 $ integerT :--:> byteStringT :--:> ReturnT byteStringT
-  IndexByteString -> comp0 $ byteStringT :--:> integerT :--:> ReturnT integerT
+  ConsByteString -> Comp0 $ integerT :--:> byteStringT :--:> ReturnT byteStringT
+  IndexByteString -> Comp0 $ byteStringT :--:> integerT :--:> ReturnT integerT
   EqualsByteString -> compareT byteStringT
   LessThanByteString -> compareT byteStringT
   LessThanEqualsByteString -> compareT byteStringT
   AppendString -> combineT stringT
   EqualsString -> compareT stringT
-  ChooseUnit -> comp1 $ unitT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
-  Trace -> comp1 $ stringT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
+  ChooseUnit -> Comp1 $ unitT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
+  Trace -> Comp1 $ stringT :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)
   BLS12_381_G1_add -> combineT g1T
-  BLS12_381_G1_scalarMul -> comp0 $ integerT :--:> g1T :--:> ReturnT g1T
+  BLS12_381_G1_scalarMul -> Comp0 $ integerT :--:> g1T :--:> ReturnT g1T
   BLS12_381_G1_equal -> compareT g1T
-  BLS12_381_G1_hashToGroup -> comp0 $ byteStringT :--:> byteStringT :--:> ReturnT g1T
+  BLS12_381_G1_hashToGroup -> Comp0 $ byteStringT :--:> byteStringT :--:> ReturnT g1T
   BLS12_381_G2_add -> combineT g2T
-  BLS12_381_G2_scalarMul -> comp0 $ integerT :--:> g2T :--:> ReturnT g2T
+  BLS12_381_G2_scalarMul -> Comp0 $ integerT :--:> g2T :--:> ReturnT g2T
   BLS12_381_G2_equal -> compareT g2T
-  BLS12_381_G2_hashToGroup -> comp0 $ byteStringT :--:> byteStringT :--:> ReturnT g2T
-  BLS12_381_millerLoop -> comp0 $ g1T :--:> g2T :--:> ReturnT mlResultT
+  BLS12_381_G2_hashToGroup -> Comp0 $ byteStringT :--:> byteStringT :--:> ReturnT g2T
+  BLS12_381_millerLoop -> Comp0 $ g1T :--:> g2T :--:> ReturnT mlResultT
   BLS12_381_mulMlResult -> combineT mlResultT
-  BLS12_381_finalVerify -> comp0 $ mlResultT :--:> mlResultT :--:> ReturnT boolT
-  ByteStringToInteger -> comp0 $ boolT :--:> byteStringT :--:> ReturnT integerT
-  ReadBit -> comp0 $ byteStringT :--:> integerT :--:> ReturnT boolT
-  ReplicateByte -> comp0 $ integerT :--:> integerT :--:> ReturnT byteStringT
-  ShiftByteString -> comp0 $ byteStringT :--:> integerT :--:> ReturnT byteStringT
-  RotateByteString -> comp0 $ byteStringT :--:> integerT :--:> ReturnT byteStringT
+  BLS12_381_finalVerify -> Comp0 $ mlResultT :--:> mlResultT :--:> ReturnT boolT
+  ByteStringToInteger -> Comp0 $ boolT :--:> byteStringT :--:> ReturnT integerT
+  ReadBit -> Comp0 $ byteStringT :--:> integerT :--:> ReturnT boolT
+  ReplicateByte -> Comp0 $ integerT :--:> integerT :--:> ReturnT byteStringT
+  ShiftByteString -> Comp0 $ byteStringT :--:> integerT :--:> ReturnT byteStringT
+  RotateByteString -> Comp0 $ byteStringT :--:> integerT :--:> ReturnT byteStringT
   where
     combineT :: ValT AbstractTy -> CompT AbstractTy
-    combineT t = comp0 $ t :--:> t :--:> ReturnT t
+    combineT t = Comp0 $ t :--:> t :--:> ReturnT t
     compareT :: ValT AbstractTy -> CompT AbstractTy
-    compareT t = comp0 $ t :--:> t :--:> ReturnT boolT
+    compareT t = Comp0 $ t :--:> t :--:> ReturnT boolT
 
 -- | All three-argument primitives provided by Plutus.
 --
@@ -378,19 +373,19 @@ typeThreeArgFunc = \case
   VerifyEcdsaSecp256k1Signature -> signatureT
   VerifySchnorrSecp256k1Signature -> signatureT
   IfThenElse ->
-    comp1 $
+    Comp1 $
       boolT
         :--:> tyvar Z ix0
         :--:> tyvar Z ix0
         :--:> ReturnT (tyvar Z ix0)
   IntegerToByteString ->
-    comp0 $
+    Comp0 $
       boolT :--:> integerT :--:> integerT :--:> ReturnT byteStringT
   AndByteString -> bitwiseT
   OrByteString -> bitwiseT
   XorByteString -> bitwiseT
   ExpModInteger ->
-    comp0 $
+    Comp0 $
       integerT
         :--:> integerT
         :--:> integerT
@@ -398,14 +393,14 @@ typeThreeArgFunc = \case
   where
     signatureT :: CompT AbstractTy
     signatureT =
-      comp0 $
+      Comp0 $
         byteStringT
           :--:> byteStringT
           :--:> byteStringT
           :--:> ReturnT boolT
     bitwiseT :: CompT AbstractTy
     bitwiseT =
-      comp0 $
+      Comp0 $
         boolT
           :--:> byteStringT
           :--:> byteStringT

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -3,6 +3,7 @@ module Covenant.Test
   )
 where
 
+import Control.Applicative ((<|>))
 import Covenant.Index (count0)
 import Covenant.Type
   ( AbstractTy,
@@ -16,12 +17,12 @@ import Covenant.Type
         StringT,
         UnitT
       ),
-    CompT (CompT),
+    CompT (Comp0, CompN),
+    CompTInternal (ArgsAndResult),
     ValT (Abstraction, BuiltinFlat, ThunkT),
   )
 import Data.Coerce (coerce)
 import Data.Vector qualified as Vector
-import Data.Vector.NonEmpty qualified as NonEmpty
 import Test.QuickCheck
   ( Arbitrary (arbitrary, shrink),
     Gen,
@@ -76,21 +77,19 @@ instance Arbitrary Concrete where
                 pure . BuiltinFlat $ BLS12_381_G1_ElementT,
                 pure . BuiltinFlat $ BLS12_381_G2_ElementT,
                 pure . BuiltinFlat $ BLS12_381_MlResultT,
-                ThunkT . CompT count0 <$> (NonEmpty.consV <$> go (size `quot` 4) <*> liftArbitrary (go (size `quot` 4)))
+                ThunkT . Comp0 <$> (ArgsAndResult <$> liftArbitrary (go (size `quot` 4)) <*> go (size `quot` 4))
               ]
   {-# INLINEABLE shrink #-}
   shrink (Concrete v) =
     Concrete <$> case v of
       -- impossible
       Abstraction _ -> []
-      ThunkT (CompT _ ts) ->
-        -- Note (Koz, 06/04/2025): This is needed because non-empty Vectors
-        -- don't have Arbitrary instances.
-        ThunkT . CompT count0 <$> do
-          let asList = NonEmpty.toList ts
-          shrunk <- fmap coerce . shrink . fmap Concrete $ asList
-          case shrunk of
-            [] -> []
-            x : xs -> pure (NonEmpty.consV x . Vector.fromList $ xs)
+      ThunkT (CompN _ (ArgsAndResult args result)) ->
+        ThunkT . CompN count0 <$> do
+          let argsList = Vector.toList args
+          argsList' <- fmap coerce . shrink . fmap Concrete $ argsList
+          result' <- fmap coerce . shrink . Concrete $ result
+          let args' = Vector.fromList argsList'
+          pure (ArgsAndResult args' result) <|> pure (ArgsAndResult args result')
       -- Can't shrink this
       BuiltinFlat _ -> []

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -18,7 +18,7 @@ import Covenant.Type
         UnitT
       ),
     CompT (Comp0, CompN),
-    CompTInternal (ArgsAndResult),
+    CompTBody (ArgsAndResult),
     ValT (Abstraction, BuiltinFlat, ThunkT),
   )
 import Data.Coerce (coerce)

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -85,13 +85,34 @@ import Data.Vector.NonEmpty (NonEmptyVector)
 import Data.Vector.NonEmpty qualified as NonEmpty
 import Optics.Core (preview)
 
--- | @since 1.0.0
+-- | The body of a computation type that doesn't take any arguments and produces
+-- the a result of the given value type. Use this just as you would a
+-- data constructor.
+--
+-- = Example
+--
+-- * @'ReturnT' 'integerT'@ is @!Integer@
+--
+-- @since 1.0.0
 pattern ReturnT :: forall (a :: Type). ValT a -> CompTInternal a
 pattern ReturnT x <- CompTInternal (returnHelper -> Just x)
   where
     ReturnT x = CompTInternal (NonEmpty.singleton x)
 
--- | @since 1.0.0
+-- | Given a type of argument, and the body of another computation type,
+-- construct a copy of the body, adding an extra argument of the argument type.
+-- Use this just as you would a data constructor.
+--
+-- = Note
+--
+-- Together with 'ReturnT', these two patterns provide an exhaustive pattern
+-- match.
+--
+-- = Example
+--
+-- * @'integerT :--:> ReturnT 'byteStringT'@ is @Integer -> !ByteString@
+--
+-- @since 1.0.0
 pattern (:--:>) ::
   forall (a :: Type).
   ValT a ->
@@ -103,7 +124,16 @@ pattern x :--:> xs <- CompTInternal (arrowHelper -> Just (x, xs))
 
 infixr 1 :--:>
 
--- | @since 1.0.0
+-- | A view of a computation type as a 'Vector' of its argument types, together
+-- with its result type. Can be used as a data constructor, and is an exhaustive
+-- match.
+--
+-- = Example
+--
+-- * @'ArgsAndResult' ('Vector.fromList' ['integerT', 'integerT']) 'integerT'@
+--   is @Integer -> Integer -> !Integer@
+--
+-- @since 1.0.0
 pattern ArgsAndResult ::
   forall (a :: Type).
   Vector (ValT a) ->
@@ -124,7 +154,8 @@ pattern ArgsAndResult args result <- (argsAndResultHelper -> (args, result))
 arity :: forall (a :: Type). CompT a -> Int
 arity (CompT _ (CompTInternal xs)) = NonEmpty.length xs - 1
 
--- | A computation type that does not bind any type variables.
+-- | A computation type that does not bind any type variables. Use this like a
+-- data constructor.
 --
 -- @since 1.0.0
 pattern Comp0 ::
@@ -136,7 +167,8 @@ pattern Comp0 xs <- (countHelper 0 -> Just xs)
     Comp0 xs = CompT count0 xs
 
 -- | A computation type that binds one type variable (that
--- is, something whose type is @forall a . ... -> ...)@.
+-- is, something whose type is @forall a . ... -> ...)@. Use this like a data
+-- constructor.
 --
 -- @since 1.0.0
 pattern Comp1 ::
@@ -148,7 +180,8 @@ pattern Comp1 xs <- (countHelper 1 -> Just xs)
     Comp1 xs = CompT count1 xs
 
 -- | A computation type that binds two type variables (that
--- is, something whose type is @forall a b . ... -> ...)@.
+-- is, something whose type is @forall a b . ... -> ...)@. Use this like a data
+-- constructor.
 --
 -- @since 1.0.0
 pattern Comp2 ::
@@ -160,7 +193,8 @@ pattern Comp2 xs <- (countHelper 2 -> Just xs)
     Comp2 xs = CompT count2 xs
 
 -- | A computation type that binds three type variables
--- (that is, something whose type is @forall a b c . ... -> ...)@.
+-- (that is, something whose type is @forall a b c . ... -> ...)@. Use this like
+-- a data constructor.
 --
 -- @since 1.0.0
 pattern Comp3 ::
@@ -172,7 +206,8 @@ pattern Comp3 xs <- (countHelper 3 -> Just xs)
     Comp3 xs = CompT count3 xs
 
 -- | A general way to construct and deconstruct computations which bind an
--- arbitrary number of type variables.
+-- arbitrary number of type variables. Use this like a data constructor. Unlike
+-- the other @Comp@ patterns, 'CompN' is exhaustive if matched on.
 --
 -- @since 1.0.0
 pattern CompN ::

--- a/src/Covenant/Util.hs
+++ b/src/Covenant/Util.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Module: Covenant.Util
+--
+-- Various helpers that don't fit anywhere else.
+--
+-- @since 1.0.0
+module Covenant.Util
+  ( pattern NilV,
+    pattern ConsV,
+  )
+where
+
+import Data.Kind (Type)
+import Data.Vector.Generic (Vector)
+import Data.Vector.Generic qualified as Vector
+
+-- | A pattern matching helper for vectors (of all types), corresponding to @[]@
+-- for lists. This pattern is bidirectional, which means it can be used just
+-- like a data constructor.
+--
+-- @since 1.0.0
+pattern NilV :: forall (a :: Type) (v :: Type -> Type). (Vector v a) => v a
+pattern NilV <- (Vector.uncons -> Nothing)
+  where
+    NilV = Vector.empty
+
+-- | A pattern matching helper for vectors (of all types), corresponding to @x :
+-- xs@-style matches. This is a read-only pattern, which means you can match
+-- with it, but not construct; this is done because @cons@ for vectors is
+-- inefficient and should thus be used consciously, using appropriate functions.
+--
+-- Together with 'NilV', 'ConsV' provides an exhaustive match.
+--
+-- @since 1.0.0
+pattern ConsV ::
+  forall (a :: Type) (v :: Type -> Type).
+  (Vector v a) =>
+  a ->
+  v a ->
+  v a
+pattern ConsV x xs <- (Vector.uncons -> Just (x, xs))
+
+{-# COMPLETE NilV, ConsV #-}

--- a/test/primops/Main.hs
+++ b/test/primops/Main.hs
@@ -7,14 +7,14 @@ import Covenant.Prim
   )
 import Covenant.Type
   ( AbstractTy (BoundAt),
-    CompT (CompT),
+    CompT,
     Renamed (Unifiable),
+    arity,
     renameCompT,
     runRenameM,
   )
 import Data.Functor.Classes (liftEq)
 import Data.Kind (Type)
-import Data.Vector.NonEmpty qualified as NonEmpty
 import Test.QuickCheck
   ( Arbitrary (arbitrary),
     Property,
@@ -98,9 +98,6 @@ mkRenameProp typingFun = forAll arbitrary $ \f ->
    in case result of
         Left err -> counterexample (show err) False
         Right renamed -> property $ liftEq eqRenamedVar t renamed
-
-arity :: forall (a :: Type). CompT a -> Int
-arity (CompT _ xs) = NonEmpty.length xs - 1
 
 -- In our context, the _only_ variables we have are unifiable. If we see
 -- anything else, we know we've messed up somewhere. Furthermore, the indexes


### PR DESCRIPTION
This PR adds several improvements:

* The 'interior' of `CompT` has been broken into its own type, with its own construction helpers `ReturnT` and `:--:>`. This is similar to the previous situation, but now that we're not writing patterns over a 'raw' `NonEmptyVector`, it should make the API much easier to understand.
* `CompT`'s constructor is now hidden. Instead, there are several patterns: the exhaustive `CompN`, which corresponds to how `CompT`'s data constructor used to be used, and `Comp0`, `Comp1`, `Comp2` and `Comp3`, which are constructor versions of `comp0` and friends. `comp0` and friends are thus removed.
* `NilV` and `ConsV` are provided to make pattern matching on vectors easier, in `Covenant.Util`.
* `CompT` can now be taken apart using `ArgsAndResult`, which acts a view over a `Vector` of arguments, and a result.

I'm not massively sold on `CompTInternal` as a name, so ideas on its improvement would be great.