### PR TITLE
ASG rebuild

### DIFF
--- a/covenant.cabal
+++ b/covenant.cabal
@@ -90,6 +90,7 @@ library
   exposed-modules:
     Control.Monad.Action
     Control.Monad.HashCons
+    Covenant.ASG
     Covenant.Constant
     Covenant.DeBruijn
     Covenant.Index

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -1,0 +1,131 @@
+module Covenant.ASG
+  ( Id,
+    Ref,
+    ASGNode,
+    CovenantTypeError
+      ( BrokenIdReference,
+        ForceCompType,
+        ForceNonThunk,
+        ForceError,
+        ThunkValType,
+        ThunkError
+      ),
+    builtin1,
+    builtin2,
+    builtin3,
+    force,
+    err,
+    lit,
+    thunk,
+  )
+where
+
+import Control.Monad.Except (MonadError (throwError))
+import Control.Monad.HashCons (MonadHashCons (refTo))
+import Covenant.Constant (AConstant, typeConstant)
+import Covenant.Internal.Term
+  ( ASGNode (ACompNode, AValNode, AnError),
+    ASGNodeType (CompNodeType, ErrorNodeType, ValNodeType),
+    CompNodeInfo
+      ( Builtin1Internal,
+        Builtin2Internal,
+        Builtin3Internal,
+        ForceInternal
+      ),
+    CovenantTypeError
+      ( BrokenIdReference,
+        ForceCompType,
+        ForceError,
+        ForceNonThunk,
+        ThunkError,
+        ThunkValType
+      ),
+    Id,
+    Ref,
+    ValNodeInfo (LitInternal, ThunkInternal),
+    typeId,
+    typeRef,
+  )
+import Covenant.Internal.Type (ValT (ThunkT))
+import Covenant.Prim
+  ( OneArgFunc,
+    ThreeArgFunc,
+    TwoArgFunc,
+    typeOneArgFunc,
+    typeThreeArgFunc,
+    typeTwoArgFunc,
+  )
+import Data.Kind (Type)
+
+-- | @since 1.0.0
+builtin1 ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m) =>
+  OneArgFunc ->
+  m Id
+builtin1 bi = do
+  let node = ACompNode (typeOneArgFunc bi) . Builtin1Internal $ bi
+  refTo node
+
+-- | @since 1.0.0
+builtin2 ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m) =>
+  TwoArgFunc ->
+  m Id
+builtin2 bi = do
+  let node = ACompNode (typeTwoArgFunc bi) . Builtin2Internal $ bi
+  refTo node
+
+-- | @since 1.0.0
+builtin3 ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m) =>
+  ThreeArgFunc ->
+  m Id
+builtin3 bi = do
+  let node = ACompNode (typeThreeArgFunc bi) . Builtin3Internal $ bi
+  refTo node
+
+-- | @since 1.0.0
+force ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m, MonadError CovenantTypeError m) =>
+  Ref ->
+  m Id
+force r = do
+  refT <- typeRef r
+  case refT of
+    ValNodeType t -> case t of
+      ThunkT compT -> refTo . ACompNode compT . ForceInternal $ r
+      _ -> throwError . ForceNonThunk $ t
+    CompNodeType t -> throwError . ForceCompType $ t
+    ErrorNodeType -> throwError ForceError
+
+-- | @since 1.0.0
+err ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m) =>
+  m Id
+err = refTo AnError
+
+-- | @since 1.0.0
+lit ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m) =>
+  AConstant ->
+  m Id
+lit c = refTo . AValNode (typeConstant c) . LitInternal $ c
+
+-- | @since 1.0.0
+thunk ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m, MonadError CovenantTypeError m) =>
+  Id ->
+  m Id
+thunk i = do
+  idT <- typeId i
+  case idT of
+    CompNodeType t -> refTo . AValNode (ThunkT t) . ThunkInternal $ i
+    ValNodeType t -> throwError . ThunkValType $ t
+    ErrorNodeType -> throwError ThunkError

--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -17,6 +17,9 @@ where
 import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.HashCons (MonadHashCons (lookupRef))
 import Covenant.Constant (AConstant)
+import Covenant.DeBruijn (DeBruijn)
+import Covenant.Index (Index)
+import Covenant.Internal.Rename (RenameError)
 import Covenant.Internal.Type (AbstractTy, CompT, ValT)
 import Covenant.Prim (OneArgFunc, ThreeArgFunc, TwoArgFunc)
 import Data.Kind (Type)
@@ -31,6 +34,19 @@ data CovenantTypeError
   | ForceError
   | ThunkValType (ValT AbstractTy)
   | ThunkError
+  | ApplyToValType (ValT AbstractTy)
+  | ApplyToError
+  | ApplyCompType (CompT AbstractTy)
+  | RenameFunctionFailed (CompT AbstractTy) RenameError
+  | RenameArgumentFailed (ValT AbstractTy) RenameError
+  | NoSuchArgument DeBruijn (Index "arg")
+  | ReturnCompType (CompT AbstractTy)
+  deriving stock
+    ( -- | @since 1.0.0
+      Eq,
+      -- | @since 1.0.0
+      Show
+    )
 
 -- | A unique identifier for a node in a Covenant program.
 --
@@ -68,7 +84,7 @@ typeId i = do
 -- | An argument passed to a function in a Covenant program.
 --
 -- @since 1.0.0
-data Arg = Arg Word64 (ValT AbstractTy)
+data Arg = Arg DeBruijn (Index "arg") (ValT AbstractTy)
   deriving stock
     ( -- | @since 1.0.0
       Eq,
@@ -80,7 +96,7 @@ data Arg = Arg Word64 (ValT AbstractTy)
 
 -- | @since 1.0.0
 typeArg :: Arg -> ValT AbstractTy
-typeArg (Arg _ t) = t
+typeArg (Arg _ _ t) = t
 
 -- | A general reference in a Covenant program. This is one of the following:
 --

--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -1,5 +1,6 @@
 module Covenant.Internal.Term
-  ( Id (..),
+  ( CovenantTypeError (..),
+    Id (..),
     typeId,
     Arg (..),
     typeArg,
@@ -23,7 +24,13 @@ import Data.Vector (Vector)
 import Data.Word (Word64)
 
 -- | @since 1.0.0
-newtype CovenantTypeError = BrokenIdReference Id
+data CovenantTypeError
+  = BrokenIdReference Id
+  | ForceCompType (CompT AbstractTy)
+  | ForceNonThunk (ValT AbstractTy)
+  | ForceError
+  | ThunkValType (ValT AbstractTy)
+  | ThunkError
 
 -- | A unique identifier for a node in a Covenant program.
 --


### PR DESCRIPTION
This PR continues the work required to integrate the CBPV type system into the term level. In this PR we have:

* A `ScopeInfo` type, designed to keep information about arguments
* Various helper construction functions, similar to the old design, which work in a capability-based monadic stack to handle hash consing and such

Applications and their typing has not been done yet, pending additional work on the unifier to handle error types.