### PR TITLE
Wildcards now track true level as well

### DIFF
--- a/src/Covenant/Internal/Rename.hs
+++ b/src/Covenant/Internal/Rename.hs
@@ -216,7 +216,7 @@ renameAbstraction (BoundAt scope index) = RenameM $ do
             -- This is a unifiable variable
             then Unifiable index
             -- This is a wildcard variable
-            else Wildcard uniqueScopeId index
+            else Wildcard uniqueScopeId trueLevel index
 
 -- Given a number of abstractions bound by a scope, modify the state to track
 -- that scope.

--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -90,11 +90,12 @@ data Renamed
     -- bindings.
     Unifiable (Index "tyvar")
   | -- | /Must/ unify with everything, except with other distinct wildcards in the
-    -- same scope. First field is a unique /scope/ identifier, second is the
-    -- positional index within that scope. We must have unique identifiers for
-    -- wildcard scopes, as wildcards unify with everything /except/ other
-    -- wildcards in the same scope.
-    Wildcard Word64 (Index "tyvar")
+    -- same scope. First field is a unique /scope/ identifier; second is its
+    -- \'true level\' simialr to @'Rigid'@; third is the positional index within
+    -- its scope. We must have unique identifiers for wildcard scopes, as
+    -- wildcards unify with everything /except/ other wildcards in the /same/
+    -- scope, and child scopes aren't unique.
+    Wildcard Word64 Int (Index "tyvar")
   deriving stock
     ( -- | @since 1.0.0
       Eq,
@@ -359,7 +360,7 @@ prettyRenamedWithContext :: forall (ann :: Type). Renamed -> PrettyM ann (Doc an
 prettyRenamedWithContext = \case
   Rigid offset index -> lookupAbstraction offset index
   Unifiable i -> lookupAbstraction 0 i
-  Wildcard w64 i -> pure $ "_" <> viaShow w64 <> "#" <> pretty (review intIndex i)
+  Wildcard w64 offset i -> pure $ pretty offset <> "_" <> viaShow w64 <> "#" <> pretty (review intIndex i)
 
 lookupAbstraction :: forall (ann :: Type). Int -> Index "tyvar" -> PrettyM ann (Doc ann)
 lookupAbstraction offset argIndex = do

--- a/test/renaming/Main.hs
+++ b/test/renaming/Main.hs
@@ -132,7 +132,7 @@ testConstT2 = do
           Abstraction (Unifiable ix0)
             :--:> ReturnT
               ( ThunkT . Comp1 $
-                  Abstraction (Wildcard 1 ix0)
+                  Abstraction (Wildcard 1 2 ix0)
                     :--:> ReturnT (Abstraction (Unifiable ix0))
               )
   let result = runRenameM . renameCompT $ constT

--- a/test/type-applications/Main.hs
+++ b/test/type-applications/Main.hs
@@ -223,7 +223,7 @@ propUnifyWildcardConcrete = forAllShrink arbitrary shrink $ \(Concrete t) ->
    in withRenamedComp (Comp0 $ thunk :--:> ReturnT integerT) $ \f ->
         let argT = ThunkT . Comp0 $ t :--:> ReturnT integerT
          in withRenamedVals (Identity argT) $ \(Identity argT') ->
-              let lhs = ThunkT . Comp1 $ Abstraction (Wildcard 1 ix0) :--:> ReturnT integerT
+              let lhs = ThunkT . Comp1 $ Abstraction (Wildcard 1 2 ix0) :--:> ReturnT integerT
                   expected = Left . DoesNotUnify lhs $ argT'
                   actual = checkApp f [argT']
                in expected === actual
@@ -328,7 +328,7 @@ propUnifyWildcardRigid = forAllShrink arbitrary shrink $ \(scope, index) ->
    in withRenamedComp (Comp0 $ thunk :--:> ReturnT integerT) $ \f ->
         let argT = ThunkT . Comp0 $ tyvar (S scope) index :--:> ReturnT integerT
          in withRenamedVals (Identity argT) $ \(Identity argT') ->
-              let lhs = ThunkT . Comp1 $ Abstraction (Wildcard 1 ix0) :--:> ReturnT integerT
+              let lhs = ThunkT . Comp1 $ Abstraction (Wildcard 1 2 ix0) :--:> ReturnT integerT
                   expected = Left . DoesNotUnify lhs $ argT'
                   actual = checkApp f [argT']
                in expected === actual


### PR DESCRIPTION
A PR necessary for completing the work started in #60 . This addresses a problem with wildcard type variables post-application: in order to restore their `AbstractTy` names, we need to know the true level to compute the DeBruijn index. However, at the moment, wildcards don't remember their true level: only a unique child scope identifier, which isn't connected (directly and predictably) to its true level.

This PR adds an additional field to wildcards to remember their true level. No other functionality is affected by this, other than the way they prettyprint.