### PR TITLE
Lambda and application construction

### DIFF
--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -21,6 +21,7 @@ import Covenant.DeBruijn (DeBruijn)
 import Covenant.Index (Index)
 import Covenant.Internal.Rename (RenameError)
 import Covenant.Internal.Type (AbstractTy, CompT, ValT)
+import Covenant.Internal.Unification (TypeAppError)
 import Covenant.Prim (OneArgFunc, ThreeArgFunc, TwoArgFunc)
 import Data.Kind (Type)
 import Data.Vector (Vector)
@@ -39,6 +40,7 @@ data CovenantTypeError
   | ApplyCompType (CompT AbstractTy)
   | RenameFunctionFailed (CompT AbstractTy) RenameError
   | RenameArgumentFailed (ValT AbstractTy) RenameError
+  | UnificationError TypeAppError
   | NoSuchArgument DeBruijn (Index "arg")
   | ReturnCompType (CompT AbstractTy)
   | LambdaResultsInValType (ValT AbstractTy)

--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -41,6 +41,11 @@ data CovenantTypeError
   | RenameArgumentFailed (ValT AbstractTy) RenameError
   | NoSuchArgument DeBruijn (Index "arg")
   | ReturnCompType (CompT AbstractTy)
+  | LambdaResultsInValType (ValT AbstractTy)
+  | LambdaResultsInNonReturn (CompT AbstractTy)
+  | ReturnWrapsError
+  | ReturnWrapsCompType (CompT AbstractTy)
+  | WrongReturnType (ValT AbstractTy) (ValT AbstractTy)
   deriving stock
     ( -- | @since 1.0.0
       Eq,


### PR DESCRIPTION
Closes (in a technical sense) #8 and #9 . Tests are still absent, and there's no concrete 'final' ASG representation yet, but to expedite Milestone 2 work, this is being sent as-is.

Features:

* `lam` and `app` construction helpers for ASG nodes for lambdas and applications
* A function to undo renaming, designed for use after unification is done