### PR TITLE
Base functors for flat types

### DIFF
--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -277,8 +277,8 @@ naturalBaseFunctor = DataDeclaration "Natural_F" count1 constrs SOP
   where
     constrs :: Vector (Constructor AbstractTy)
     constrs =
-      [ Constructor "ZeroNatF" [],
-        Constructor "SuccNatF" [Abstraction . BoundAt Z $ ix0]
+      [ Constructor "ZeroNat_F" [],
+        Constructor "SuccNat_F" [Abstraction . BoundAt Z $ ix0]
       ]
 
 negativeBaseFunctor :: DataDeclaration AbstractTy
@@ -286,8 +286,8 @@ negativeBaseFunctor = DataDeclaration "Negative_F" count1 constrs SOP
   where
     constrs :: Vector (Constructor AbstractTy)
     constrs =
-      [ Constructor "ZeroNegF" [],
-        Constructor "PredNegF" [Abstraction . BoundAt Z $ ix0]
+      [ Constructor "ZeroNeg_F" [],
+        Constructor "PredNeg_F" [Abstraction . BoundAt Z $ ix0]
       ]
 
 byteStringBaseFunctor :: DataDeclaration AbstractTy
@@ -295,8 +295,8 @@ byteStringBaseFunctor = DataDeclaration "ByteString_F" count1 constrs SOP
   where
     constrs :: Vector (Constructor AbstractTy)
     constrs =
-      [ Constructor "EmptyByteStringF" [],
-        Constructor "ConsByteStringF" [BuiltinFlat IntegerT, Abstraction . BoundAt Z $ ix0]
+      [ Constructor "EmptyByteString_F" [],
+        Constructor "ConsByteString_F" [BuiltinFlat IntegerT, Abstraction . BoundAt Z $ ix0]
       ]
 
 -- Helpers

--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 {-# HLINT ignore "Use camelCase" #-}
@@ -25,6 +26,9 @@ module Covenant.Internal.Type
     -- generic utility for debugging/testing
     prettyStr,
     checkStrategy,
+    naturalBaseFunctor,
+    negativeBaseFunctor,
+    byteStringBaseFunctor,
   )
 where
 
@@ -34,12 +38,14 @@ import Control.Monad.Reader
     asks,
     runReader,
   )
-import Covenant.DeBruijn (DeBruijn)
+import Covenant.DeBruijn (DeBruijn (Z))
 import Covenant.Index
   ( Count,
     Index,
+    count1,
     intCount,
     intIndex,
+    ix0,
   )
 import Data.Functor.Classes (Eq1 (liftEq))
 import Data.Kind (Type)
@@ -265,6 +271,33 @@ data BuiltinFlatT
       -- | @since 1.0.0
       Show
     )
+
+naturalBaseFunctor :: DataDeclaration AbstractTy
+naturalBaseFunctor = DataDeclaration "Natural_F" count1 constrs SOP
+  where
+    constrs :: Vector (Constructor AbstractTy)
+    constrs =
+      [ Constructor "ZeroNatF" [],
+        Constructor "SuccNatF" [Abstraction . BoundAt Z $ ix0]
+      ]
+
+negativeBaseFunctor :: DataDeclaration AbstractTy
+negativeBaseFunctor = DataDeclaration "Negative_F" count1 constrs SOP
+  where
+    constrs :: Vector (Constructor AbstractTy)
+    constrs =
+      [ Constructor "ZeroNegF" [],
+        Constructor "PredNegF" [Abstraction . BoundAt Z $ ix0]
+      ]
+
+byteStringBaseFunctor :: DataDeclaration AbstractTy
+byteStringBaseFunctor = DataDeclaration "ByteString_F" count1 constrs SOP
+  where
+    constrs :: Vector (Constructor AbstractTy)
+    constrs =
+      [ Constructor "EmptyByteStringF" [],
+        Constructor "ConsByteStringF" [BuiltinFlat IntegerT, Abstraction . BoundAt Z $ ix0]
+      ]
 
 -- Helpers
 


### PR DESCRIPTION
Fixes #78. Specifically, we add base functor definitions for `Integer` and `ByteString`, which effectively treat them as so:

```haskell
data Natural = ZeroNat | SuccNat Natural

data Negative = ZeroNeg | PredNeg Negative

data ByteString = EmptyByteString | ConsByteString Integer ByteString
```

The two base functors for `Integer` are less than ideal, because this introduces an implicit error condition: someone trying to tear down a negative number using the `Natural` base functor, or a positive one using the `Negative` base functor. However, this is the simplest solution for now, and we can always refine it later. The special-casing in this situation doesn't matter for codegen, as we'd have to treat these specially anyway.