### PR TITLE
Koz/clean up type internal

### DIFF
--- a/covenant.cabal
+++ b/covenant.cabal
@@ -95,7 +95,6 @@ common bench-lang
 library
   import: lang
   exposed-modules:
-    -- FIXME: Re-export the important bits from somewhere else or expose this module (ask Koz which is better)
     Control.Monad.Action
     Control.Monad.HashCons
     Covenant.ASG
@@ -112,6 +111,7 @@ library
     Covenant.Internal.KindCheck
     Covenant.Internal.Ledger
     Covenant.Internal.Rename
+    Covenant.Internal.Strategy
     Covenant.Internal.Term
     Covenant.Internal.Type
     Covenant.Internal.Unification

--- a/src/Covenant/Internal/Ledger.hs
+++ b/src/Covenant/Internal/Ledger.hs
@@ -5,16 +5,17 @@ where
 
 import Covenant.DeBruijn (DeBruijn (Z))
 import Covenant.Index (Count, count0, count1, count2, ix0, ix1)
-import Covenant.Type
-  ( -- weirdly, can't coerece w/o importing the constructor?
-    AbstractTy (BoundAt),
+import Covenant.Internal.Strategy
+  ( InternalStrategy (InternalAssocMapStrat, InternalDataStrat, InternalListStrat, InternalPairStrat),
+    PlutusDataStrategy (ConstrData, NewtypeData),
+  )
+import Covenant.Internal.Type
+  ( AbstractTy (BoundAt),
     BuiltinFlatT (BoolT, ByteStringT, IntegerT),
     Constructor (Constructor),
     ConstructorName (ConstructorName),
     DataDeclaration (DataDeclaration),
     DataEncoding (BuiltinStrategy, PlutusData),
-    InternalStrategy (InternalAssocMapStrat, InternalDataStrat, InternalListStrat, InternalPairStrat),
-    PlutusDataStrategy (ConstrData, NewtypeData),
     TyName (TyName),
     ValT (Abstraction, BuiltinFlat, Datatype),
   )

--- a/src/Covenant/Internal/Strategy.hs
+++ b/src/Covenant/Internal/Strategy.hs
@@ -1,0 +1,70 @@
+module Covenant.Internal.Strategy
+  ( DataEncoding (..),
+    PlutusDataStrategy (..),
+    InternalStrategy (..),
+    PlutusDataConstructor (..),
+  )
+where
+
+-- | @since 1.1.0
+data DataEncoding
+  = SOP
+  | PlutusData PlutusDataStrategy
+  | BuiltinStrategy InternalStrategy
+  deriving stock
+    ( -- | @since 1.1.0
+      Show,
+      -- | @since 1.1.0
+      Eq,
+      -- | @since 1.1.0
+      Ord
+    )
+
+-- NOTE: Wrapped data-primitive (Integer + ByteString) require a special case for their encoders, which was originally
+--       part of a "WrapperData" strategy here which we generalized to the NewtypeData strategy.
+
+-- | @since 1.1.0
+data PlutusDataStrategy
+  = EnumData
+  | ProductListData
+  | ConstrData
+  | NewtypeData
+  deriving stock
+    ( -- | @since 1.1.0
+      Show,
+      -- | @since 1.1.0
+      Eq,
+      -- | @since 1.1.0
+      Ord
+    )
+
+-- | @since 1.1.0
+data PlutusDataConstructor
+  = PlutusI
+  | PlutusB
+  | PlutusConstr
+  | PlutusList
+  | PlutusMap
+  deriving stock
+    ( -- | @since 1.1.0
+      Show,
+      -- | @since 1.1.0
+      Eq,
+      -- | @since 1.1.0
+      Ord
+    )
+
+-- | @since 1.1.0
+data InternalStrategy
+  = InternalListStrat
+  | InternalPairStrat
+  | InternalDataStrat
+  | InternalAssocMapStrat
+  deriving stock
+    ( -- | @since 1.1.0
+      Show,
+      -- | @since 1.1.0
+      Eq,
+      -- | @since 1.1.0
+      Ord
+    )

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -55,9 +55,25 @@ module Covenant.Type
     TyName (TyName),
     ConstructorName (ConstructorName),
     DataEncoding (SOP, PlutusData, BuiltinStrategy),
-    PlutusDataConstructor (PD_I, PD_B, PD_Constructor, PD_List),
-    PlutusDataStrategy (EnumData, ProductListData, ConstrData, NewtypeData),
-    InternalStrategy (InternalListStrat, InternalPairStrat, InternalDataStrat, InternalAssocMapStrat),
+    PlutusDataConstructor
+      ( PlutusI,
+        PlutusB,
+        PlutusConstr,
+        PlutusList,
+        PlutusMap
+      ),
+    PlutusDataStrategy
+      ( EnumData,
+        ProductListData,
+        ConstrData,
+        NewtypeData
+      ),
+    InternalStrategy
+      ( InternalListStrat,
+        InternalPairStrat,
+        InternalDataStrat,
+        InternalAssocMapStrat
+      ),
 
     -- * Datatype sanity checking
     cycleCheck,
@@ -88,6 +104,27 @@ import Covenant.Internal.Rename
     renameValT,
     runRenameM,
   )
+import Covenant.Internal.Strategy
+  ( InternalStrategy
+      ( InternalAssocMapStrat,
+        InternalDataStrat,
+        InternalListStrat,
+        InternalPairStrat
+      ),
+    PlutusDataConstructor
+      ( PlutusB,
+        PlutusConstr,
+        PlutusI,
+        PlutusList,
+        PlutusMap
+      ),
+    PlutusDataStrategy
+      ( ConstrData,
+        EnumData,
+        NewtypeData,
+        ProductListData
+      ),
+  )
 import Covenant.Internal.Type
   ( AbstractTy (BoundAt),
     BuiltinFlatT
@@ -106,9 +143,6 @@ import Covenant.Internal.Type
     ConstructorName (ConstructorName),
     DataDeclaration (DataDeclaration, OpaqueData),
     DataEncoding (BuiltinStrategy, PlutusData, SOP),
-    InternalStrategy (InternalAssocMapStrat, InternalDataStrat, InternalListStrat, InternalPairStrat),
-    PlutusDataConstructor (PD_B, PD_Constructor, PD_I, PD_List),
-    PlutusDataStrategy (ConstrData, EnumData, NewtypeData, ProductListData),
     Renamed (Rigid, Unifiable, Wildcard),
     TyName (TyName),
     ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),


### PR DESCRIPTION
Minor cleanup of `Covenant.Type.Internal`. This is mostly reorganization and documentation, but a few structural changes to the entire codebase are also included:

* Stuff related to encodings is now in its own module
* A few import chains were broken

More needs doing, but this involves untangling the large mess that is prettyprinting.