### PR TITLE
Datatype Info, ASG Env

### DIFF
--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -171,7 +171,7 @@ import Covenant.Internal.Type
     CompT (CompT),
     CompTBody (CompTBody),
     Renamed,
-    ValT (ThunkT),
+    ValT (ThunkT), TyName,
   )
 import Covenant.Internal.Unification (checkApp)
 import Covenant.Prim
@@ -203,6 +203,7 @@ import Optics.Core
     review,
     (%),
   )
+import Covenant.Data (DatatypeInfo)
 
 -- | A fully-assembled Covenant ASG.
 --
@@ -243,6 +244,23 @@ topLevelNode asg@(ASG (rootId, _)) = nodeAt rootId asg
 -- @since 1.0.0
 nodeAt :: Id -> ASG -> ASGNode
 nodeAt i (ASG (_, mappings)) = fromJust . Map.lookup i $ mappings
+
+
+data ASGEnv = ASGEnv ScopeInfo (Map TyName DatatypeInfo)
+
+instance (k ~ A_Lens, a ~ ScopeInfo, b ~ ScopeInfo) =>
+  LabelOptic "scopeInfo" k ASGEnv ASGEnv a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic = lens (\(ASGEnv si _) -> si)
+                    (\(ASGEnv _ dti) si -> ASGEnv si dti)
+
+instance (k ~ A_Lens, a ~ Map TyName DatatypeInfo, b ~ Map TyName DatatypeInfo) =>
+  LabelOptic "datatypeInfo" k ASGEnv ASGEnv a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic = lens (\(ASGEnv _ dti) -> dti)
+                    (\(ASGEnv si _) dti -> ASGEnv si dti)
 
 -- | A tracker for scope-related information while building an ASG
 -- programmatically. Currently only tracks available arguments.
@@ -369,7 +387,7 @@ data CovenantError
 --
 -- @since 1.0.0
 newtype ASGBuilder (a :: Type)
-  = ASGBuilder (ReaderT ScopeInfo (ExceptT CovenantTypeError (HashConsT Id ASGNode Identity)) a)
+  = ASGBuilder (ReaderT ASGEnv (ExceptT CovenantTypeError (HashConsT Id ASGNode Identity)) a)
   deriving
     ( -- | @since 1.0.0
       Functor,
@@ -378,23 +396,24 @@ newtype ASGBuilder (a :: Type)
       -- | @since 1.0.0
       Monad,
       -- | @since 1.0.0
-      MonadReader ScopeInfo,
+      MonadReader ASGEnv,
       -- | @since 1.0.0
       MonadError CovenantTypeError,
       -- | @since 1.0.0
       MonadHashCons Id ASGNode
     )
-    via ReaderT ScopeInfo (ExceptT CovenantTypeError (HashConsT Id ASGNode Identity))
+    via ReaderT ASGEnv (ExceptT CovenantTypeError (HashConsT Id ASGNode Identity))
 
 -- | Executes an 'ASGBuilder' to make a \'finished\' ASG.
 --
 -- @since 1.0.0
 runASGBuilder ::
   forall (a :: Type).
+  Map TyName DatatypeInfo ->
   ASGBuilder a ->
   Either CovenantError ASG
-runASGBuilder (ASGBuilder comp) =
-  case runIdentity . runHashConsT . runExceptT . runReaderT comp . ScopeInfo $ Vector.empty of
+runASGBuilder tyDict (ASGBuilder comp) =
+  case runIdentity . runHashConsT . runExceptT . runReaderT comp $  ASGEnv (ScopeInfo  Vector.empty) tyDict of
     (result, bm) -> case result of
       Left err' -> Left . TypeError bm $ err'
       Right _ -> case Bimap.size bm of
@@ -413,14 +432,14 @@ runASGBuilder (ASGBuilder comp) =
 -- @since 1.0.0
 arg ::
   forall (m :: Type -> Type).
-  (MonadError CovenantTypeError m, MonadReader ScopeInfo m) =>
+  (MonadError CovenantTypeError m, MonadReader ASGEnv m) =>
   DeBruijn ->
   Index "arg" ->
   m Arg
 arg scope index = do
-  let scopeAsInt = review asInt scope
+  let scopeAsInt = review asInt scope 
   let indexAsInt = review intIndex index
-  lookedUp <- asks (preview (#argumentInfo % ix scopeAsInt % ix indexAsInt))
+  lookedUp <- asks (preview (#scopeInfo % #argumentInfo % ix scopeAsInt % ix indexAsInt))
   case lookedUp of
     Nothing -> throwError . NoSuchArgument scope $ index
     Just t -> pure . Arg scope index $ t
@@ -513,13 +532,13 @@ ret r = do
 -- @since 1.0.0
 lam ::
   forall (m :: Type -> Type).
-  (MonadHashCons Id ASGNode m, MonadError CovenantTypeError m, MonadReader ScopeInfo m) =>
+  (MonadHashCons Id ASGNode m, MonadError CovenantTypeError m, MonadReader ASGEnv m) =>
   CompT AbstractTy ->
   m Id ->
   m Id
 lam expectedT@(CompT _ (CompTBody xs)) bodyComp = do
   let (args, resultT) = NonEmpty.unsnoc xs
-  bodyId <- local (over #argumentInfo (Vector.cons args)) bodyComp
+  bodyId <- local (over (#scopeInfo % #argumentInfo) (Vector.cons args)) bodyComp
   bodyNode <- lookupRef bodyId
   case bodyNode of
     Nothing -> throwError . BrokenIdReference $ bodyId

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -401,7 +401,7 @@ newtype ASGBuilder (a :: Type)
       Applicative,
       -- | @since 1.0.0
       Monad,
-      -- | @since 1.0.0
+      -- | @since 1.1.0
       MonadReader ASGEnv,
       -- | @since 1.0.0
       MonadError CovenantTypeError,

--- a/src/Covenant/Data.hs
+++ b/src/Covenant/Data.hs
@@ -1,6 +1,14 @@
 {-# LANGUAGE ViewPatterns #-}
 
-module Covenant.Data (mkBaseFunctor, isRecursiveChildOf, allComponentTypes, hasRecursive, mkBBF, noPhantomTyVars, everythingOf) where
+module Covenant.Data (mkBaseFunctor,
+                      isRecursiveChildOf,
+                      allComponentTypes,
+                      hasRecursive,
+                      mkBBF,
+                      noPhantomTyVars,
+                      everythingOf,
+                      DatatypeInfo(DatatypeInfo),
+                      ) where
 
 import Control.Monad.Reader (MonadReader (ask, local), Reader, runReader)
 import Covenant.DeBruijn (DeBruijn (S, Z), asInt)
@@ -22,7 +30,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Vector qualified as V
 import Data.Vector.NonEmpty qualified as NEV
-import Optics.Core (folded, preview, review, toListOf, view, (%))
+import Optics.Core (folded, preview, review, toListOf, view, (%), A_Lens, LabelOptic (labelOptic), lens)
 
 {- NOTE: For the purposes of base functor transformation, we follow the pattern established by Edward Kmett's
          'recursion-schemes' library. That is, we regard a datatype as "recursive" if and only if at least one
@@ -228,3 +236,51 @@ mkBBF (DataDeclaration _ numVars ctors _)
      - Actually this is slightly false, we need to "bump" all of the indices inside constructor arms by one (because
        they now occur within a Thunk), but after that bump everything is stable as indicated above.
 -}
+
+
+{- Here for lack of a better place to put it (has to be available to Unification and ASG)
+-}
+
+-- | Packages up all of the relevation datatype information needed
+-- for the ASGBuilder. Note that only certain datatypes have a BB or BB/BF form
+-- (we do not generate forms that are "useless")
+data DatatypeInfo =
+  DatatypeInfo
+    { _originalDecl :: DataDeclaration AbstractTy
+    , _baseFunctor :: Maybe (DataDeclaration AbstractTy)
+    , _bbForm :: Maybe (ValT AbstractTy)
+    , _bbBaseF :: Maybe (ValT AbstractTy)}
+    deriving stock
+    ( -- | @since 1.1.0
+     Eq,
+      -- | @since 1.1.0
+     Show
+    )
+
+instance (k ~ A_Lens, a ~ DataDeclaration AbstractTy, b ~ DataDeclaration AbstractTy) =>
+  LabelOptic "originalDecl" k DatatypeInfo DatatypeInfo a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic = lens (\(DatatypeInfo ogDecl _ _ _) -> ogDecl)
+                    (\(DatatypeInfo _ b c d) ogDecl -> DatatypeInfo ogDecl b c d)
+
+instance (k ~ A_Lens, a ~ Maybe (DataDeclaration AbstractTy), b ~ Maybe (DataDeclaration AbstractTy)) =>
+  LabelOptic "baseFunctor" k DatatypeInfo DatatypeInfo a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic = lens (\(DatatypeInfo _ baseF _ _) -> baseF)
+                    (\(DatatypeInfo a _ c d) baseF -> DatatypeInfo a baseF c d)
+
+instance (k ~ A_Lens, a ~ Maybe (ValT AbstractTy), b ~ Maybe (ValT AbstractTy)) =>
+  LabelOptic "bbForm" k DatatypeInfo DatatypeInfo a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic = lens (\(DatatypeInfo _ _ bb _) -> bb)
+                    (\(DatatypeInfo a b _ d) bb -> DatatypeInfo a b bb d)
+
+instance (k ~ A_Lens, a ~ Maybe (ValT AbstractTy), b ~ Maybe (ValT AbstractTy)) =>
+  LabelOptic "bbBaseF" k DatatypeInfo DatatypeInfo a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic = lens (\(DatatypeInfo _ _ _ bbf) -> bbf)
+                    (\(DatatypeInfo a b c _) bbf -> DatatypeInfo a b c bbf)

--- a/src/Covenant/Data.hs
+++ b/src/Covenant/Data.hs
@@ -249,7 +249,7 @@ mkBBF (DataDeclaration _ numVars ctors _)
 data DatatypeInfo
   = DatatypeInfo
   { _originalDecl :: DataDeclaration AbstractTy,
-    _baseFunctorStuff:: Maybe (DataDeclaration AbstractTy,ValT AbstractTy),
+    _baseFunctorStuff :: Maybe (DataDeclaration AbstractTy, ValT AbstractTy),
     -- NOTE: The ONLY type that won't have a BB form is `Void` (or something isomorphic to it)
     _bbForm :: Maybe (ValT AbstractTy)
   }
@@ -287,7 +287,7 @@ instance
   {-# INLINEABLE labelOptic #-}
   labelOptic =
     lens
-      (\(DatatypeInfo _ _ bb ) -> bb)
+      (\(DatatypeInfo _ _ bb) -> bb)
       (\(DatatypeInfo a b _) bb -> DatatypeInfo a b bb)
 
 instance

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -66,6 +66,7 @@ import Covenant.Util (pattern ConsV, pattern NilV)
 import Data.Coerce (coerce)
 import Data.Kind (Type)
 import Data.Maybe (fromJust)
+import Data.Map qualified as M
 import Data.Vector qualified as Vector
 import Optics.Core (preview, review)
 import Test.QuickCheck
@@ -120,20 +121,20 @@ unitEmptyASG :: IO ()
 unitEmptyASG = do
   let builtUp = pure ()
   let expected = Left EmptyASG
-  let actual = runASGBuilder builtUp
+  let actual = runASGBuilder M.empty builtUp
   assertEqual "" expected actual
 
 unitSingleError :: IO ()
 unitSingleError = do
   let builtUp = err
   let expected = Left TopLevelError
-  let actual = runASGBuilder builtUp
+  let actual = runASGBuilder M.empty builtUp
   assertEqual "" expected actual
 
 unitForceError :: IO ()
 unitForceError = do
   let builtUp = err >>= \i -> force (AnId i)
-  let result = runASGBuilder builtUp
+  let result = runASGBuilder M.empty builtUp
   case result of
     Left (TypeError _ ForceError) -> pure ()
     _ -> assertFailure $ "Unexpected result: " <> show result
@@ -141,7 +142,7 @@ unitForceError = do
 unitThunkError :: IO ()
 unitThunkError = do
   let builtUp = err >>= thunk
-  let result = runASGBuilder builtUp
+  let result = runASGBuilder M.empty builtUp
   case result of
     Left (TypeError _ ThunkError) -> pure ()
     _ -> assertFailure $ "Unexpected result: " <> show result
@@ -433,12 +434,12 @@ failWrongError :: CovenantError -> Property
 failWrongError err' = failWithCounterExample ("Unexpected error: " <> show err')
 
 withCompilationFailure :: ASGBuilder Id -> (CovenantError -> Property) -> Property
-withCompilationFailure comp cb = case runASGBuilder comp of
+withCompilationFailure comp cb = case runASGBuilder M.empty comp of
   Left err' -> cb err'
   Right asg -> failWithCounterExample ("Unexpected success: " <> show asg)
 
 withCompilationSuccess :: ASGBuilder Id -> (ASG -> Property) -> Property
-withCompilationSuccess comp cb = case runASGBuilder comp of
+withCompilationSuccess comp cb = case runASGBuilder M.empty comp of
   Left err' -> failWithCounterExample ("Unexpected failure: " <> show err')
   Right asg -> cb asg
 

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -65,8 +65,8 @@ import Covenant.Type
 import Covenant.Util (pattern ConsV, pattern NilV)
 import Data.Coerce (coerce)
 import Data.Kind (Type)
-import Data.Maybe (fromJust)
 import Data.Map qualified as M
+import Data.Maybe (fromJust)
 import Data.Vector qualified as Vector
 import Optics.Core (preview, review)
 import Test.QuickCheck


### PR DESCRIPTION
Adds a `DatatypeInfo` type for "everything we need to know about a datatype", embeds it in `ASGBuilder`, fixes some type signatures/tests 