### PR TITLE
Restore missing builtins involving data types

### DIFF
--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -35,6 +35,7 @@ module Covenant.ASG
       ( Builtin1,
         Builtin2,
         Builtin3,
+        Builtin6,
         Lam,
         Force,
         Return
@@ -83,6 +84,7 @@ module Covenant.ASG
     builtin1,
     builtin2,
     builtin3,
+    builtin6,
     force,
     ret,
     lam,
@@ -135,6 +137,7 @@ import Covenant.Internal.Term
       ( Builtin1Internal,
         Builtin2Internal,
         Builtin3Internal,
+        Builtin6Internal,
         ForceInternal,
         LamInternal,
         ReturnInternal
@@ -178,9 +181,11 @@ import Covenant.Internal.Type
 import Covenant.Internal.Unification (checkApp)
 import Covenant.Prim
   ( OneArgFunc,
+    SixArgFunc,
     ThreeArgFunc,
     TwoArgFunc,
     typeOneArgFunc,
+    typeSixArgFunc,
     typeThreeArgFunc,
     typeTwoArgFunc,
   )
@@ -319,6 +324,12 @@ pattern Builtin2 f <- Builtin2Internal f
 pattern Builtin3 :: ThreeArgFunc -> CompNodeInfo
 pattern Builtin3 f <- Builtin3Internal f
 
+-- | A Plutus primop with six arguments.
+--
+-- @since 1.1.0
+pattern Builtin6 :: SixArgFunc -> CompNodeInfo
+pattern Builtin6 f <- Builtin6Internal f
+
 -- | Force a thunk back into the computation it wraps.
 --
 -- @since 1.0.0
@@ -337,7 +348,7 @@ pattern Return r <- ReturnInternal r
 pattern Lam :: Id -> CompNodeInfo
 pattern Lam i <- LamInternal i
 
-{-# COMPLETE Builtin1, Builtin2, Builtin3, Force, Return, Lam #-}
+{-# COMPLETE Builtin1, Builtin2, Builtin3, Builtin6, Force, Return, Lam #-}
 
 -- | A compile-time literal of a flat builtin type.
 --
@@ -484,6 +495,18 @@ builtin3 ::
   m Id
 builtin3 bi = do
   let node = ACompNode (typeThreeArgFunc bi) . Builtin3Internal $ bi
+  refTo node
+
+-- | As 'builtin1', but for six-argument primops.
+--
+-- @since 1.1.0
+builtin6 ::
+  forall (m :: Type -> Type).
+  (MonadHashCons Id ASGNode m) =>
+  SixArgFunc ->
+  m Id
+builtin6 bi = do
+  let node = ACompNode (typeSixArgFunc bi) . Builtin6Internal $ bi
   refTo node
 
 -- | Given a reference to a thunk, turn it back into a computation. Will fail if

--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -22,7 +22,7 @@ import Covenant.Index (Index)
 import Covenant.Internal.Rename (RenameError)
 import Covenant.Internal.Type (AbstractTy, CompT, ValT)
 import Covenant.Internal.Unification (TypeAppError)
-import Covenant.Prim (OneArgFunc, ThreeArgFunc, TwoArgFunc)
+import Covenant.Prim (OneArgFunc, SixArgFunc, ThreeArgFunc, TwoArgFunc)
 import Data.Kind (Type)
 import Data.Vector (Vector)
 import Data.Word (Word64)
@@ -213,6 +213,8 @@ data CompNodeInfo
   = Builtin1Internal OneArgFunc
   | Builtin2Internal TwoArgFunc
   | Builtin3Internal ThreeArgFunc
+  | -- | @since 1.1.0
+    Builtin6Internal SixArgFunc
   | LamInternal Id
   | ForceInternal Ref
   | ReturnInternal Ref

--- a/src/Covenant/Prim.hs
+++ b/src/Covenant/Prim.hs
@@ -21,8 +21,8 @@ module Covenant.Prim
     typeTwoArgFunc,
     ThreeArgFunc (..),
     typeThreeArgFunc,
-    -- SixArgFunc (..),
-    -- typeSixArgFunc,
+    SixArgFunc (..),
+    typeSixArgFunc,
   )
 where
 
@@ -439,10 +439,9 @@ typeThreeArgFunc = \case
           :--:> byteStringT
           :--:> ReturnT byteStringT
 
-{-
 -- | All six-argument primitives provided by Plutus.
 --
--- @since 1.0.0
+-- @since 1.1.0
 data SixArgFunc
   = ChooseData
   | CaseData
@@ -457,11 +456,34 @@ data SixArgFunc
 
 -- | Does not shrink.
 --
--- @since 1.0.0
+-- @since 1.1.0
 instance Arbitrary SixArgFunc where
   {-# INLINEABLE arbitrary #-}
   arbitrary = elements [ChooseData, CaseData]
--}
+
+-- | Produce the type of a six-argument primop.
+--
+-- @since 1.1.0
+typeSixArgFunc :: SixArgFunc -> CompT AbstractTy
+typeSixArgFunc = \case
+  ChooseData ->
+    Comp1 $
+      dataT
+        :--:> aT
+        :--:> aT
+        :--:> aT
+        :--:> aT
+        :--:> aT
+        :--:> ReturnT aT
+  CaseData ->
+    Comp1 $
+      ThunkT (Comp0 $ integerT :--:> listT dataT :--:> ReturnT aTOuter)
+        :--:> ThunkT (Comp0 $ listT (pairT dataT dataT) :--:> ReturnT aTOuter)
+        :--:> ThunkT (Comp0 $ listT dataT :--:> ReturnT aTOuter)
+        :--:> ThunkT (Comp0 $ integerT :--:> ReturnT aTOuter)
+        :--:> ThunkT (Comp0 $ byteStringT :--:> ReturnT aTOuter)
+        :--:> dataT
+        :--:> ReturnT aT
 
 -- Helpers
 

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -22,6 +22,9 @@ module Covenant.Type
 
     -- * Value types
     ValT (..),
+    dataTypeT,
+    dataType1T,
+    dataType2T,
     BuiltinFlatT (..),
     byteStringT,
     integerT,
@@ -129,6 +132,7 @@ import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Data.Vector.NonEmpty (NonEmptyVector)
 import Data.Vector.NonEmpty qualified as NonEmpty
+import GHC.Exts (fromListN)
 import Optics.Core (preview)
 
 -- | The body of a computation type that doesn't take any arguments and produces
@@ -271,6 +275,24 @@ pattern CompN count xs <- CompT count xs
 -- @since 1.0.0
 tyvar :: DeBruijn -> Index "tyvar" -> ValT AbstractTy
 tyvar db = Abstraction . BoundAt db
+
+-- | Helper for referring to compound data types with no type variables.
+--
+-- @since 1.1.0
+dataTypeT :: forall (a :: Type). TyName -> ValT a
+dataTypeT tn = Datatype tn Vector.empty
+
+-- | Helper for referring to compound data types with one type variable.
+--
+-- @since 1.1.0
+dataType1T :: TyName -> ValT AbstractTy -> ValT AbstractTy
+dataType1T tn = Datatype tn . Vector.singleton
+
+-- | Helper for referring to compound data types with two type variables.
+--
+-- @since 1.1.0
+dataType2T :: TyName -> ValT AbstractTy -> ValT AbstractTy -> ValT AbstractTy
+dataType2T tn v1 v2 = Datatype tn . fromListN 2 $ [v1, v2]
 
 -- | Helper for defining the value type of builtin bytestrings.
 --


### PR DESCRIPTION
Milestone 1 omitted a large collection of primitives due to not having support for non-'flat' data types. These have now been restored. In particular, this meant adding new constructors and functionality for arity-6 primops, which were not previously included at all.

Tests for this functionality have to wait until #76 at least, as without the ability to introduce data type terms into the ASG, we can't test any of this.