### PR TITLE
Koz/bump ci

### DIFF
--- a/.github/workflows/covenant.yml
+++ b/.github/workflows/covenant.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up HLint
         uses: haskell-actions/hlint-setup@v2
         with:
-          version: 3.8
+          version: 3.10
       - name: Run HLint
         uses: haskell-actions/hlint-run@v2
         with:

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -11,9 +11,9 @@ license-file: LICENSE
 author: Koz Ross, Sean Hunter
 maintainer: koz@mlabs.city, sean@mlabs.city
 bug-reports: https://github.com/mlabs-haskell/covenant/issues
-copyright: (C) MLabs 2024
+copyright: (C) MLabs 2024-2025
 category: Covenant
-tested-with: ghc ==9.8.4 || ==9.10.1 || ==9.12.1
+tested-with: ghc ==9.8.4 || ==9.10.2 || ==9.12.2
 build-type: Simple
 extra-source-files:
   CHANGELOG.md

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,6 +4,6 @@
 set -euxo pipefail
 
 # Word splitting here is intentional
-ormolu --mode=inplace $(find src test -name "*.hs")
+ormolu --mode=check $(find src test -name "*.hs")
 
-cabal-gild --io=covenant.cabal
+cabal-gild --mode=check --io=covenant.cabal


### PR DESCRIPTION
This updates the CI to use the more recent minor versions of GHC 9.10 and 9.12, as well as a more current `hlint`. Additionally, the git hooks no longer automatically format files, but instead only run checks.