### PR TITLE
More prettyprinting refactors

### DIFF
--- a/covenant.cabal
+++ b/covenant.cabal
@@ -110,6 +110,7 @@ library
   other-modules:
     Covenant.Internal.KindCheck
     Covenant.Internal.Ledger
+    Covenant.Internal.PrettyPrint
     Covenant.Internal.Rename
     Covenant.Internal.Strategy
     Covenant.Internal.Term

--- a/src/Covenant/Data.hs
+++ b/src/Covenant/Data.hs
@@ -15,6 +15,7 @@ where
 import Control.Monad.Reader (MonadReader (ask, local), Reader, runReader)
 import Covenant.DeBruijn (DeBruijn (S, Z), asInt)
 import Covenant.Index (Count, Index, count0, intCount, intIndex)
+import Covenant.Internal.PrettyPrint (ScopeBoundary (ScopeBoundary))
 import Covenant.Internal.Type
   ( AbstractTy (BoundAt),
     CompT (CompT),
@@ -22,7 +23,6 @@ import Covenant.Internal.Type
     Constructor (Constructor),
     ConstructorName (ConstructorName),
     DataDeclaration (DataDeclaration, OpaqueData),
-    ScopeBoundary (ScopeBoundary),
     TyName (TyName),
     ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),
   )

--- a/src/Covenant/Internal/PrettyPrint.hs
+++ b/src/Covenant/Internal/PrettyPrint.hs
@@ -1,9 +1,29 @@
-module Covenant.Internal.PrettyPrint (prettyStr) where
+module Covenant.Internal.PrettyPrint
+  ( ScopeBoundary (..),
+    PrettyContext (..),
+    PrettyM,
+    runPrettyM,
+    prettyStr,
+  )
+where
 
+import Control.Monad.Reader
+  ( MonadReader,
+    Reader,
+    runReader,
+  )
 import Data.Kind (Type)
+import Data.Map.Strict (Map)
 import Data.Text qualified as T
+import Data.Vector (Vector)
+import Optics.Core
+  ( A_Lens,
+    LabelOptic (labelOptic),
+    lens,
+  )
 import Prettyprinter
-  ( Pretty (pretty),
+  ( Doc,
+    Pretty (pretty),
     defaultLayoutOptions,
     layoutPretty,
   )
@@ -11,3 +31,66 @@ import Prettyprinter.Render.Text (renderStrict)
 
 prettyStr :: forall (a :: Type). (Pretty a) => a -> String
 prettyStr = T.unpack . renderStrict . layoutPretty defaultLayoutOptions . pretty
+
+newtype ScopeBoundary = ScopeBoundary Int
+  deriving (Show, Eq, Ord, Num, Real, Enum, Integral) via Int
+
+-- Keeping the field names for clarity even if we don't use them
+data PrettyContext (ann :: Type)
+  = PrettyContext
+  { _boundIdents :: Map ScopeBoundary (Vector (Doc ann)),
+    _currentScope :: ScopeBoundary,
+    _varStream :: [Doc ann]
+  }
+
+instance
+  (k ~ A_Lens, a ~ Map ScopeBoundary (Vector (Doc ann)), b ~ Map ScopeBoundary (Vector (Doc ann))) =>
+  LabelOptic "boundIdents" k (PrettyContext ann) (PrettyContext ann) a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic =
+    lens
+      (\(PrettyContext x _ _) -> x)
+      (\(PrettyContext _ y z) x -> PrettyContext x y z)
+
+instance
+  (k ~ A_Lens, a ~ ScopeBoundary, b ~ ScopeBoundary) =>
+  LabelOptic "currentScope" k (PrettyContext ann) (PrettyContext ann) a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic =
+    lens
+      (\(PrettyContext _ x _) -> x)
+      (\(PrettyContext x _ z) y -> PrettyContext x y z)
+
+instance
+  (k ~ A_Lens, a ~ [Doc ann], b ~ [Doc ann]) =>
+  LabelOptic "varStream" k (PrettyContext ann) (PrettyContext ann) a b
+  where
+  {-# INLINEABLE labelOptic #-}
+  labelOptic =
+    lens
+      (\(PrettyContext _ _ x) -> x)
+      (\(PrettyContext x y _) z -> PrettyContext x y z)
+
+-- Maybe make a newtype with error reporting since this can fail, but do later since *should't* fail
+newtype PrettyM (ann :: Type) (a :: Type) = PrettyM (Reader (PrettyContext ann) a)
+  deriving
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadReader (PrettyContext ann)
+    )
+    via (Reader (PrettyContext ann))
+
+runPrettyM :: forall (ann :: Type) (a :: Type). PrettyM ann a -> a
+runPrettyM (PrettyM ma) = runReader ma (PrettyContext mempty 0 infiniteVars)
+  where
+    -- Lazily generated infinite list of variables. Will start with a, b, c...
+    -- and cycle around to a1, b2, c3 etc.
+    -- We could do something more sophisticated but this should work.
+    infiniteVars :: [Doc ann]
+    infiniteVars =
+      let aToZ = ['a' .. 'z']
+          intStrings = ("" <$ aToZ) <> map (show @Integer) [0 ..]
+       in zipWith (\x xs -> pretty (x : xs)) aToZ intStrings

--- a/src/Covenant/Internal/PrettyPrint.hs
+++ b/src/Covenant/Internal/PrettyPrint.hs
@@ -1,0 +1,13 @@
+module Covenant.Internal.PrettyPrint (prettyStr) where
+
+import Data.Kind (Type)
+import Data.Text qualified as T
+import Prettyprinter
+  ( Pretty (pretty),
+    defaultLayoutOptions,
+    layoutPretty,
+  )
+import Prettyprinter.Render.Text (renderStrict)
+
+prettyStr :: forall (a :: Type). (Pretty a) => a -> String
+prettyStr = T.unpack . renderStrict . layoutPretty defaultLayoutOptions . pretty

--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -12,7 +12,6 @@ module Covenant.Internal.Type
     ValT (..),
     BuiltinFlatT (..),
     TyName (..),
-    ScopeBoundary (..), -- used in the generators
     DataEncoding (..),
     runConstructorName,
     abstraction,
@@ -26,12 +25,7 @@ module Covenant.Internal.Type
   )
 where
 
-import Control.Monad.Reader
-  ( MonadReader (local),
-    Reader,
-    asks,
-    runReader,
-  )
+import Control.Monad.Reader (asks, local)
 import Covenant.DeBruijn (DeBruijn (Z))
 import Covenant.Index
   ( Count,
@@ -40,6 +34,11 @@ import Covenant.Index
     intCount,
     intIndex,
     ix0,
+  )
+import Covenant.Internal.PrettyPrint
+  ( PrettyM,
+    ScopeBoundary (ScopeBoundary),
+    runPrettyM,
   )
 import Covenant.Internal.Strategy
   ( DataEncoding
@@ -64,7 +63,6 @@ import Covenant.Internal.Strategy
 import Covenant.Util (pattern ConsV, pattern NilV)
 import Data.Functor.Classes (Eq1 (liftEq))
 import Data.Kind (Type)
-import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.String (IsString)
@@ -447,69 +445,6 @@ byteStringBaseFunctor = DataDeclaration "ByteString_F" count1 constrs SOP
       ]
 
 -- Helpers
-
-newtype ScopeBoundary = ScopeBoundary Int
-  deriving (Show, Eq, Ord, Num, Real, Enum, Integral) via Int
-
--- Keeping the field names for clarity even if we don't use them
-data PrettyContext (ann :: Type)
-  = PrettyContext
-  { _boundIdents :: Map ScopeBoundary (Vector (Doc ann)),
-    _currentScope :: ScopeBoundary,
-    _varStream :: [Doc ann]
-  }
-
-instance
-  (k ~ A_Lens, a ~ Map ScopeBoundary (Vector (Doc ann)), b ~ Map ScopeBoundary (Vector (Doc ann))) =>
-  LabelOptic "boundIdents" k (PrettyContext ann) (PrettyContext ann) a b
-  where
-  {-# INLINEABLE labelOptic #-}
-  labelOptic =
-    lens
-      (\(PrettyContext x _ _) -> x)
-      (\(PrettyContext _ y z) x -> PrettyContext x y z)
-
-instance
-  (k ~ A_Lens, a ~ ScopeBoundary, b ~ ScopeBoundary) =>
-  LabelOptic "currentScope" k (PrettyContext ann) (PrettyContext ann) a b
-  where
-  {-# INLINEABLE labelOptic #-}
-  labelOptic =
-    lens
-      (\(PrettyContext _ x _) -> x)
-      (\(PrettyContext x _ z) y -> PrettyContext x y z)
-
-instance
-  (k ~ A_Lens, a ~ [Doc ann], b ~ [Doc ann]) =>
-  LabelOptic "varStream" k (PrettyContext ann) (PrettyContext ann) a b
-  where
-  {-# INLINEABLE labelOptic #-}
-  labelOptic =
-    lens
-      (\(PrettyContext _ _ x) -> x)
-      (\(PrettyContext x y _) z -> PrettyContext x y z)
-
--- Maybe make a newtype with error reporting since this can fail, but do later since *should't* fail
-newtype PrettyM (ann :: Type) (a :: Type) = PrettyM (Reader (PrettyContext ann) a)
-  deriving
-    ( Functor,
-      Applicative,
-      Monad,
-      MonadReader (PrettyContext ann)
-    )
-    via (Reader (PrettyContext ann))
-
-runPrettyM :: forall (ann :: Type) (a :: Type). PrettyM ann a -> a
-runPrettyM (PrettyM ma) = runReader ma (PrettyContext mempty 0 infiniteVars)
-  where
-    -- Lazily generated infinite list of variables. Will start with a, b, c...
-    -- and cycle around to a1, b2, c3 etc.
-    -- We could do something more sophisticated but this should work.
-    infiniteVars :: [Doc ann]
-    infiniteVars =
-      let aToZ = ['a' .. 'z']
-          intStrings = ("" <$ aToZ) <> map (show @Integer) [0 ..]
-       in zipWith (\x xs -> pretty (x : xs)) aToZ intStrings
 
 prettyCompTWithContext :: forall (ann :: Type). CompT Renamed -> PrettyM ann (Doc ann)
 prettyCompTWithContext (CompT count (CompTBody funArgs))

--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -19,8 +19,6 @@ module Covenant.Internal.Type
     thunkT,
     builtinFlat,
     datatype,
-    -- generic utility for debugging/testing
-    prettyStr,
     checkStrategy,
     naturalBaseFunctor,
     negativeBaseFunctor,
@@ -71,7 +69,6 @@ import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.String (IsString)
 import Data.Text (Text)
-import Data.Text qualified as T
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Data.Vector.NonEmpty (NonEmptyVector)
@@ -98,16 +95,13 @@ import Optics.Core
 import Prettyprinter
   ( Doc,
     Pretty (pretty),
-    defaultLayoutOptions,
     hsep,
     indent,
-    layoutPretty,
     parens,
     vcat,
     viaShow,
     (<+>),
   )
-import Prettyprinter.Render.Text (renderStrict)
 import Test.QuickCheck.Instances.Text ()
 
 -- | A type abstraction, using a combination of a DeBruijn index (to indicate
@@ -453,9 +447,6 @@ byteStringBaseFunctor = DataDeclaration "ByteString_F" count1 constrs SOP
       ]
 
 -- Helpers
-
-prettyStr :: forall (b :: Type). (Pretty b) => b -> String
-prettyStr = T.unpack . renderStrict . layoutPretty defaultLayoutOptions . pretty
 
 newtype ScopeBoundary = ScopeBoundary Int
   deriving (Show, Eq, Ord, Num, Real, Enum, Integral) via Int

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -37,6 +37,7 @@ import Covenant.Index
     intIndex,
     ix0,
   )
+import Covenant.Internal.PrettyPrint (prettyStr)
 import Covenant.Internal.Rename (renameDataDecl, renameValT)
 import Covenant.Internal.Type
   ( CompT (CompT),
@@ -48,7 +49,6 @@ import Covenant.Internal.Type
     ScopeBoundary,
     TyName (TyName),
     ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),
-    prettyStr,
     runConstructorName,
   )
 import Covenant.Type

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -37,7 +37,7 @@ import Covenant.Index
     intIndex,
     ix0,
   )
-import Covenant.Internal.PrettyPrint (prettyStr)
+import Covenant.Internal.PrettyPrint (ScopeBoundary, prettyStr)
 import Covenant.Internal.Rename (renameDataDecl, renameValT)
 import Covenant.Internal.Type
   ( CompT (CompT),
@@ -46,7 +46,6 @@ import Covenant.Internal.Type
     ConstructorName (ConstructorName),
     DataDeclaration (DataDeclaration, OpaqueData),
     DataEncoding (SOP),
-    ScopeBoundary,
     TyName (TyName),
     ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),
     runConstructorName,


### PR DESCRIPTION
Follow-up to #84 . This removes `PrettyM`, as well as several data types and functions specific to it, to a new module. This reduces the overall size of `Covenant.Internal.Type` even more, while also breaking a few dep chains.