### PR TITLE
Encoding Check for Type Constructors & Datatypes

### DIFF
--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -116,6 +116,7 @@ import Covenant.Constant (AConstant, typeConstant)
 import Covenant.Data (DatatypeInfo)
 import Covenant.DeBruijn (DeBruijn, asInt)
 import Covenant.Index (Index, count0, intIndex)
+import Covenant.Internal.KindCheck (checkEncodingArgs)
 import Covenant.Internal.Rename
   ( RenameError
       ( InvalidAbstractionReference
@@ -157,7 +158,7 @@ import Covenant.Internal.Term
         ThunkError,
         ThunkValType,
         UnificationError,
-        WrongReturnType
+        WrongReturnType, EncodingError
       ),
     Id,
     Ref (AnArg, AnId),
@@ -620,6 +621,7 @@ app fId argRefs = do
         tyDict <- asks (view #datatypeInfo)
         result <- either (throwError . UnificationError) pure $ checkApp tyDict renamedFT (Vector.toList renamedArgs)
         let restored = undoRename result
+        checkEncodingWithInfo tyDict restored 
         refTo . AValNode restored . AppInternal fId $ argRefs
     ValNodeType t -> throwError . ApplyToValType $ t
     ErrorNodeType -> throwError ApplyToError
@@ -664,3 +666,12 @@ renameArg r =
       Left err' -> throwError . RenameArgumentFailed t $ err'
       Right renamed -> pure . Just $ renamed
     ErrorNodeType -> pure Nothing
+
+checkEncodingWithInfo :: forall (a :: Type) (m :: Type -> Type)
+                       . MonadError CovenantTypeError m
+                      => Map TyName (DatatypeInfo a)
+                      -> ValT AbstractTy
+                      -> m ()
+checkEncodingWithInfo  tyDict valT = case checkEncodingArgs (view (#originalDecl % #datatypeEncoding)) tyDict valT of
+  Left encErr -> throwError $ EncodingError encErr
+  Right{} -> pure ()

--- a/src/Covenant/Data.hs
+++ b/src/Covenant/Data.hs
@@ -238,21 +238,23 @@ mkBBF' (DataDeclaration tn numVars ctors _)
     mkBBCtor (Constructor _ args)
       | V.null args = pure topLevelOut
       | otherwise = do
-          elimArgs <- traverse fixArg args
+          elimArgs <- fmap incAbstractionDB <$> traverse fixArg args
           elimArgs' <- lift . NEV.fromVector $ elimArgs
           let out = Abstraction $ BoundAt (S Z) outIx
           pure . ThunkT . CompT count0 . CompTBody . flip NEV.snoc out $ elimArgs'
 
     fixArg :: ValT AbstractTy -> ExceptT BBFError Maybe (ValT AbstractTy)
-    fixArg (Abstraction (BoundAt db indx)) = pure . Abstraction $ BoundAt (S db) indx
-    fixArg arg = do
+    -- fixArg (Abstraction (BoundAt db indx)) = pure . Abstraction $ BoundAt Z indx
+    fixArg  arg = do
       let isDirectRecursiveTy = runReader (isRecursiveChildOf tn arg) 0
       if isDirectRecursiveTy
-        then pure $ Abstraction (BoundAt (S Z) outIx)
+        then pure $ Abstraction (BoundAt Z outIx)
         else case arg of
           Datatype tn' dtArgs
             | tn == tn' -> throwError $ InvalidRecursion tn arg
-            | otherwise -> pure . Datatype tn' $ incAbstractionDB <$> dtArgs
+            | otherwise -> do
+               dtArgs' <- traverse fixArg dtArgs
+               pure . Datatype tn' $  dtArgs'
           _ -> pure arg
 
 {- Note (Sean, 14/05/25): Re  DeBruijn indices:

--- a/src/Covenant/Data.hs
+++ b/src/Covenant/Data.hs
@@ -245,7 +245,7 @@ mkBBF' (DataDeclaration tn numVars ctors _)
 
     fixArg :: ValT AbstractTy -> ExceptT BBFError Maybe (ValT AbstractTy)
     -- fixArg (Abstraction (BoundAt db indx)) = pure . Abstraction $ BoundAt Z indx
-    fixArg  arg = do
+    fixArg arg = do
       let isDirectRecursiveTy = runReader (isRecursiveChildOf tn arg) 0
       if isDirectRecursiveTy
         then pure $ Abstraction (BoundAt Z outIx)
@@ -253,8 +253,8 @@ mkBBF' (DataDeclaration tn numVars ctors _)
           Datatype tn' dtArgs
             | tn == tn' -> throwError $ InvalidRecursion tn arg
             | otherwise -> do
-               dtArgs' <- traverse fixArg dtArgs
-               pure . Datatype tn' $  dtArgs'
+                dtArgs' <- traverse fixArg dtArgs
+                pure . Datatype tn' $ dtArgs'
           _ -> pure arg
 
 {- Note (Sean, 14/05/25): Re  DeBruijn indices:

--- a/src/Covenant/Internal/KindCheck.hs
+++ b/src/Covenant/Internal/KindCheck.hs
@@ -212,9 +212,9 @@ checkEncodingArgs getEncoding tyDict = \case
 
     isValidSOPArg :: TyName -> ValT a -> Either (EncodingArgErr a) ()
     isValidSOPArg tn = \case
-      Abstraction{} -> pure ()
-      BuiltinFlat{} -> pure ()
-      thunk@ThunkT{} -> throwError $ EncodingArgMismatch tn thunk
+      Abstraction {} -> pure ()
+      BuiltinFlat {} -> pure ()
+      thunk@ThunkT {} -> throwError $ EncodingArgMismatch tn thunk
       Datatype tn' args' -> traverse_ (isValidSOPArg tn') args'
 
 checkEncodingArgsInDataDecl :: DataDeclaration AbstractTy -> KindCheckM AbstractTy ()

--- a/src/Covenant/Internal/KindCheck.hs
+++ b/src/Covenant/Internal/KindCheck.hs
@@ -8,7 +8,7 @@
 --       - The "count" - the number of bound tyvars in the `ValT.Datatype` representation - may be incorrect (i.e. inconsistent with the count in the declaration)
 --
 --     The checks to detect these errors are entirely independent from the checks performed during typechecking or renaming, so we do them in a separate pass.
-module Covenant.Internal.KindCheck (checkDataDecls, checkValT, KindCheckError (..), cycleCheck) where
+module Covenant.Internal.KindCheck (checkDataDecls, checkValT, KindCheckError (..), EncodingArgErr(..), cycleCheck, checkEncodingArgs) where
 
 import Control.Monad (unless)
 import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
@@ -24,7 +24,7 @@ import Covenant.Internal.Type
     TyName,
     ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),
     checkStrategy,
-    datatype,
+    datatype, DataEncoding (SOP),
   )
 import Data.Foldable (traverse_)
 import Data.Functor.Identity (Identity, runIdentity)
@@ -36,7 +36,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Vector (Vector)
 import Data.Vector qualified as V
-import Optics.Core (A_Lens, LabelOptic (labelOptic), lens, preview, review, to, view, (%))
+import Optics.Core (A_Lens, LabelOptic (labelOptic), lens, preview, review, to, view, (%), toListOf, folded)
 
 {- TODO: Explicitly separate the kind checker into two check functions:
      - One which kind checks `ValT`s to ensure:
@@ -55,6 +55,7 @@ data KindCheckError
   | ThunkConstructorArg (CompT AbstractTy) -- no polymorphic function args to ctors
   | MutualRecursionDetected (Set TyName)
   | InvalidStrategy TyName
+  | EncodingMismatch (EncodingArgErr AbstractTy)
   deriving stock (Show, Eq)
 
 newtype KindCheckContext a = KindCheckContext (Map TyName (DataDeclaration a))
@@ -98,6 +99,7 @@ checkDataDecl decl@(DataDeclaration tn _ ctors _) = do
   cycleCheck' mempty decl
   let allCtorArgs = view #constructorArgs =<< ctors
   traverse_ (checkKinds CheckDataDecl) allCtorArgs
+  checkEncodingArgsInDataDecl decl
 
 data KindCheckMode = CheckDataDecl | CheckValT
   deriving stock (Show, Eq, Ord)
@@ -151,3 +153,59 @@ cycleCheck' visited (DataDeclaration tn _ ctors _) = traverse_ (checkCtor visite
       let newVisited = Set.insert tn' vs
       nextRound <- traverse lookupDeclaration (Set.toList allTyCons)
       traverse_ (cycleCheck' newVisited) nextRound
+
+{- Arguably the closest thing to a real kind checker in the module.
+
+   Checks whether the arguments to type constructors (ValT 'Datatype's) conform with their encoding.
+
+
+-}
+
+-- First arg is the name of the type constructor w/ a bad argument, second arg is the bad argument.
+data EncodingArgErr a = EncodingArgMismatch TyName (ValT a)
+  deriving stock (Show, Eq)
+
+-- NOTE: This assumes that we've already checked that all of the relevant types *exist* in the datatype context.
+--       So, if we use this to validate data declarations, we need to make sure it happens *after* the checks that
+--       ensure that.
+checkEncodingArgs :: forall (a :: Type) (info :: Type)
+                   . (info -> DataEncoding) -- this lets us not care about whether we're doing this w/ a DataDeclaration or DatatypeInfo
+                  -> Map TyName info
+                  -> ValT a
+                  -> Either (EncodingArgErr a) ()
+checkEncodingArgs getEncoding tyDict = \case
+  Abstraction{} -> pure ()
+  BuiltinFlat{} -> pure ()
+  ThunkT (CompT _ (CompTBody args)) -> traverse_ go  args
+  Datatype tn args -> do
+    let encoding = getEncoding $ tyDict M.! tn
+    case encoding of
+      -- Might as well check all the way down
+      SOP -> traverse_ go args
+      -- Both explicit data encodings and builtins should be "morally data encoded"
+      _ -> do
+        traverse_ go args
+        traverse_ (isValidDataArg tn) args
+ where
+   go :: ValT a -> Either (EncodingArgErr a) ()
+   go = checkEncodingArgs getEncoding tyDict
+
+   isValidDataArg :: TyName -> ValT a -> Either (EncodingArgErr a) ()
+   isValidDataArg tn = \case
+     Abstraction{} -> pure ()
+     BuiltinFlat{} -> pure ()
+     thunk@ThunkT{} -> throwError $ EncodingArgMismatch tn thunk
+     dt@(Datatype tn' args') -> do
+       let encoding = getEncoding $ tyDict M.! tn'
+       case encoding of
+         SOP -> throwError $ EncodingArgMismatch tn dt
+         _ -> traverse_ go args'
+
+checkEncodingArgsInDataDecl :: DataDeclaration AbstractTy -> KindCheckM AbstractTy ()
+checkEncodingArgsInDataDecl decl = asks (view #kindCheckContext) >>= \tyDict ->
+  case traverse (checkEncodingArgs (view #datatypeEncoding) tyDict) allConstructorArgs of
+    Left encErr -> throwError $ EncodingMismatch encErr
+    Right _ -> pure ()
+ where
+   allConstructorArgs :: Vector (ValT AbstractTy)
+   allConstructorArgs = V.concat $ toListOf (#datatypeConstructors % folded % #constructorArgs) decl

--- a/src/Covenant/Internal/Ledger.hs
+++ b/src/Covenant/Internal/Ledger.hs
@@ -8,7 +8,7 @@ module Covenant.Internal.Ledger
     pair,
     list,
     tree,
-    weirderList
+    weirderList,
   )
 where
 
@@ -669,6 +669,11 @@ tree :: DataDeclaration AbstractTy
 tree = mkDecl $ Decl "Tree" count1 [Ctor "Bin" [tycon "Tree" [a], tycon "Tree" [a]], Ctor "Tip" [a]] (PlutusData ConstrData)
 
 weirderList :: DataDeclaration AbstractTy
-weirderList = mkDecl $ Decl "WeirderList" count1
-  [Ctor "Uncons" [tycon "Maybe" [tycon "Pair" [a, tycon "WeirderList" [a]]]]
-  ] (PlutusData ConstrData)
+weirderList =
+  mkDecl $
+    Decl
+      "WeirderList"
+      count1
+      [ Ctor "Uncons" [tycon "Maybe" [tycon "Pair" [a, tycon "WeirderList" [a]]]]
+      ]
+      (PlutusData ConstrData)

--- a/src/Covenant/Internal/Ledger.hs
+++ b/src/Covenant/Internal/Ledger.hs
@@ -8,6 +8,7 @@ module Covenant.Internal.Ledger
     pair,
     list,
     tree,
+    weirderList
   )
 where
 
@@ -666,3 +667,8 @@ b = Abstraction (BoundAt Z ix1)
 
 tree :: DataDeclaration AbstractTy
 tree = mkDecl $ Decl "Tree" count1 [Ctor "Bin" [tycon "Tree" [a], tycon "Tree" [a]], Ctor "Tip" [a]] (PlutusData ConstrData)
+
+weirderList :: DataDeclaration AbstractTy
+weirderList = mkDecl $ Decl "WeirderList" count1
+  [Ctor "Uncons" [tycon "Maybe" [tycon "Pair" [a, tycon "WeirderList" [a]]]]
+  ] (PlutusData ConstrData)

--- a/src/Covenant/Internal/Strategy.hs
+++ b/src/Covenant/Internal/Strategy.hs
@@ -60,8 +60,8 @@ data InternalStrategy
   | InternalPairStrat
   | InternalDataStrat
   | InternalAssocMapStrat
-  -- This exists solely so I can get a 'DataEncoding' out of an opaque, it's not really used
-  | InternalOpaqueStrat
+  | -- This exists solely so I can get a 'DataEncoding' out of an opaque, it's not really used
+    InternalOpaqueStrat
   deriving stock
     ( -- | @since 1.1.0
       Show,

--- a/src/Covenant/Internal/Strategy.hs
+++ b/src/Covenant/Internal/Strategy.hs
@@ -60,6 +60,8 @@ data InternalStrategy
   | InternalPairStrat
   | InternalDataStrat
   | InternalAssocMapStrat
+  -- This exists solely so I can get a 'DataEncoding' out of an opaque, it's not really used
+  | InternalOpaqueStrat
   deriving stock
     ( -- | @since 1.1.0
       Show,

--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -19,6 +19,7 @@ import Control.Monad.HashCons (MonadHashCons (lookupRef))
 import Covenant.Constant (AConstant)
 import Covenant.DeBruijn (DeBruijn)
 import Covenant.Index (Index)
+import Covenant.Internal.KindCheck (EncodingArgErr)
 import Covenant.Internal.Rename (RenameError)
 import Covenant.Internal.Type (AbstractTy, CompT, ValT)
 import Covenant.Internal.Unification (TypeAppError)
@@ -26,7 +27,6 @@ import Covenant.Prim (OneArgFunc, SixArgFunc, ThreeArgFunc, TwoArgFunc)
 import Data.Kind (Type)
 import Data.Vector (Vector)
 import Data.Word (Word64)
-import Covenant.Internal.KindCheck (EncodingArgErr)
 
 -- | An error that can arise during the construction of an ASG by programmatic
 -- means.
@@ -119,6 +119,7 @@ data CovenantTypeError
     -- @since 1.0.0
     WrongReturnType (ValT AbstractTy) (ValT AbstractTy)
   | -- @since 1.1.0
+
     -- | Wraps an encoding argument mismatch error from KindCheck
     EncodingError (EncodingArgErr AbstractTy)
   deriving stock

--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -26,6 +26,7 @@ import Covenant.Prim (OneArgFunc, SixArgFunc, ThreeArgFunc, TwoArgFunc)
 import Data.Kind (Type)
 import Data.Vector (Vector)
 import Data.Word (Word64)
+import Covenant.Internal.KindCheck (EncodingArgErr)
 
 -- | An error that can arise during the construction of an ASG by programmatic
 -- means.
@@ -117,6 +118,9 @@ data CovenantTypeError
     --
     -- @since 1.0.0
     WrongReturnType (ValT AbstractTy) (ValT AbstractTy)
+  | -- @since 1.1.0
+    -- | Wraps an encoding argument mismatch error from KindCheck
+    EncodingError (EncodingArgErr AbstractTy)
   deriving stock
     ( -- | @since 1.0.0
       Eq,

--- a/src/Covenant/Internal/Type.hs
+++ b/src/Covenant/Internal/Type.hs
@@ -51,8 +51,8 @@ import Covenant.Internal.Strategy
       ( InternalAssocMapStrat,
         InternalDataStrat,
         InternalListStrat,
-        InternalPairStrat,
-        InternalOpaqueStrat
+        InternalOpaqueStrat,
+        InternalPairStrat
       ),
     PlutusDataConstructor,
     PlutusDataStrategy
@@ -406,9 +406,8 @@ instance
   {-# INLINEABLE labelOptic #-}
   labelOptic =
     lens
-      (\case OpaqueData{} -> BuiltinStrategy InternalOpaqueStrat; DataDeclaration _ _ _ enc -> enc)
+      (\case OpaqueData {} -> BuiltinStrategy InternalOpaqueStrat; DataDeclaration _ _ _ enc -> enc)
       (\decl enc -> case decl of OpaqueData tn x -> OpaqueData tn x; DataDeclaration tn x y _ -> DataDeclaration tn x y enc)
-
 
 checkStrategy :: forall (a :: Type). DataDeclaration a -> Bool
 checkStrategy = \case

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -21,6 +21,7 @@ module Covenant.Test
     tyAppTestDatatypes,
     list,
     tree,
+    weirderList
   )
 where
 
@@ -50,7 +51,7 @@ import Covenant.Index
     ix0,
     ix1,
   )
-import Covenant.Internal.Ledger (CtorBuilder (Ctor), DeclBuilder (Decl), ledgerTypes, list, maybeT, mkDecl, pair, tree)
+import Covenant.Internal.Ledger (CtorBuilder (Ctor), DeclBuilder (Decl), ledgerTypes, list, maybeT, mkDecl, pair, tree, weirderList)
 import Covenant.Internal.PrettyPrint (ScopeBoundary, prettyStr)
 import Covenant.Internal.Rename (renameDataDecl, renameValT)
 import Covenant.Internal.Type

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -21,7 +21,7 @@ module Covenant.Test
     tyAppTestDatatypes,
     list,
     tree,
-    weirderList
+    weirderList,
   )
 where
 

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -102,7 +102,7 @@ import Covenant.Index
     intCount,
   )
 -- re-export for tests
-import Covenant.Internal.KindCheck (checkDataDecls, cycleCheck, checkEncodingArgs)
+import Covenant.Internal.KindCheck (checkDataDecls, checkEncodingArgs, cycleCheck)
 import Covenant.Internal.PrettyPrint (prettyStr)
 import Covenant.Internal.Rename
   ( RenameError

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -83,6 +83,7 @@ module Covenant.Type
     -- * Datatype sanity checking
     cycleCheck,
     checkDataDecls,
+    checkEncodingArgs,
 
     -- * for tests
     prettyStr,
@@ -101,7 +102,7 @@ import Covenant.Index
     intCount,
   )
 -- re-export for tests
-import Covenant.Internal.KindCheck (checkDataDecls, cycleCheck)
+import Covenant.Internal.KindCheck (checkDataDecls, cycleCheck, checkEncodingArgs)
 import Covenant.Internal.PrettyPrint (prettyStr)
 import Covenant.Internal.Rename
   ( RenameError

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -87,6 +87,7 @@ module Covenant.Type
 
     -- * for tests
     prettyStr,
+    tyCon,
   )
 where
 
@@ -418,3 +419,6 @@ countHelper expected (CompT actual xs) = do
   expectedCount <- preview intCount expected
   guard (expectedCount == actual)
   pure xs
+
+tyCon :: TyName -> [ValT a] -> ValT a
+tyCon tn args = Datatype tn (Vector.fromList args)

--- a/test/bb/Main.hs
+++ b/test/bb/Main.hs
@@ -18,7 +18,8 @@ import Covenant.Test
     list,
     prettyDeclSet,
     tree,
-    tyAppTestDatatypes, weirderList,
+    tyAppTestDatatypes,
+    weirderList,
   )
 import Covenant.Type
   ( AbstractTy (BoundAt),
@@ -28,7 +29,8 @@ import Covenant.Type
     renameCompT,
     renameValT,
     runRenameM,
-    tyvar, tyCon,
+    tyCon,
+    tyvar,
   )
 import Data.Map qualified as M
 import Data.Maybe (catMaybes, fromJust)
@@ -128,16 +130,20 @@ bbfWeirderList = testCase "bbfWeirderList" $ do
   let bbf = mkBBF weirderList
   bbf' <- either (assertFailure . show) (maybe (assertFailure "no bbf for tree") pure) bbf
   assertEqual "bbfWeirderTree" expectedWeirdBBF bbf'
- where
-   -- forall a r. (Maybe (a,r) -> r) -> r
-   expectedWeirdBBF = ThunkT (
-     Comp2 (
-         ThunkT (Comp0 (
-             tyCon "Maybe" [tyCon "Pair" [tyvar (S Z) ix0, tyvar (S Z) ix1]]
-             :--:> ReturnT (tyvar (S Z) ix1)))
-         :--:> ReturnT (tyvar Z ix1 )
-                   )
-                             )
+  where
+    -- forall a r. (Maybe (a,r) -> r) -> r
+    expectedWeirdBBF =
+      ThunkT
+        ( Comp2
+            ( ThunkT
+                ( Comp0
+                    ( tyCon "Maybe" [tyCon "Pair" [tyvar (S Z) ix0, tyvar (S Z) ix1]]
+                        :--:> ReturnT (tyvar (S Z) ix1)
+                    )
+                )
+                :--:> ReturnT (tyvar Z ix1)
+            )
+        )
 
 -- Simple datatype unification unit test. Checks whether `data Unit = Unit` has the expected BB form
 testMonotypeBB :: TestTree

--- a/test/kindcheck/Main.hs
+++ b/test/kindcheck/Main.hs
@@ -1,20 +1,27 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use camelCase" #-}
 module Main (main) where
 
 import Covenant.DeBruijn (DeBruijn (Z))
 import Covenant.Index (count0, count1, ix0)
 import Covenant.Test (ledgerTypes)
 import Covenant.Type
-  ( AbstractTy (BoundAt),
-    BuiltinFlatT (IntegerT),
-    Constructor (Constructor),
-    DataDeclaration (DataDeclaration, OpaqueData),
-    DataEncoding (PlutusData, SOP),
-    PlutusDataStrategy (ConstrData),
-    ValT (Abstraction, BuiltinFlat, Datatype),
-    checkDataDecls,
-    checkEncodingArgs,
-    cycleCheck,
-  )
+    ( AbstractTy(BoundAt),
+      BuiltinFlatT(IntegerT),
+      Constructor(Constructor),
+      DataDeclaration(DataDeclaration, OpaqueData),
+      DataEncoding(PlutusData, SOP),
+      PlutusDataStrategy(ConstrData),
+      ValT(Abstraction, BuiltinFlat, Datatype, ThunkT),
+      CompT(Comp1),
+      checkDataDecls,
+      checkEncodingArgs,
+      cycleCheck,
+      TyName,
+      tyvar,
+      tyCon,
+      CompTBody((:--:>)),
+      CompTBody(ReturnT) )
 import Data.Map qualified as M
 import Data.Vector qualified as V
 import Optics.Core (view)
@@ -29,7 +36,10 @@ main =
       testCase "singleSelfRec" $ runCycleCheck [intList],
       expectFail $ testCase "mutRecShouldFail" (runCycleCheck [mutRec1, mutRec2]),
       checkLedgerTypes,
-      shouldFailEncodingCheck
+      simpleEncodingMismatch,
+      nestedThunkArg,
+      noThunkArgsToSOPTyCons_for_now,
+      goodSOPArg 
     ]
 
 checkLedgerTypes :: TestTree
@@ -40,13 +50,29 @@ checkLedgerTypes =
     . foldr (\x acc -> M.insert (view #datatypeName x) x acc) M.empty
     $ ledgerTypes
 
-shouldFailEncodingCheck :: TestTree
-shouldFailEncodingCheck =
-  expectFail . testCase "encodingArgsShouldFail" $
+
+encodingCheck :: String -> [DataDeclaration AbstractTy] -> ValT AbstractTy -> TestTree
+encodingCheck testNm tyDict valT = testCase testNm  $
     either (assertFailure . show) pure $
-      checkEncodingArgs (view #datatypeEncoding) testTyDict encodingMismatch
-  where
-    testTyDict = foldr (\decl acc -> M.insert (view #datatypeName decl) decl acc) M.empty [maybee, intList]
+      checkEncodingArgs (view #datatypeEncoding) (mkTyDict tyDict) valT
+
+shouldFailEncodingCheck :: String -> [DataDeclaration AbstractTy] -> ValT AbstractTy -> TestTree
+shouldFailEncodingCheck tnm tyDict valT = expectFail $  encodingCheck tnm tyDict valT
+
+simpleEncodingMismatch :: TestTree
+simpleEncodingMismatch = shouldFailEncodingCheck  "simpleEncodingMismatch" [maybee,intList] encodingMismatch
+
+noThunkArgsToSOPTyCons_for_now :: TestTree
+noThunkArgsToSOPTyCons_for_now = shouldFailEncodingCheck "no thunk args to SOP tycons (for now)" [maybeSOP] badSOPThunk
+
+nestedThunkArg :: TestTree
+nestedThunkArg = shouldFailEncodingCheck "nestedThunkArg" [maybee] badThunkArg
+
+goodSOPArg :: TestTree
+goodSOPArg = encodingCheck "goodSOP" [maybeSOP] goodSOP
+
+mkTyDict :: forall a. [DataDeclaration a] -> M.Map TyName (DataDeclaration a)
+mkTyDict = foldr (\decl acc -> M.insert (view #datatypeName decl) decl acc) M.empty
 
 runCycleCheck :: [DataDeclaration AbstractTy] -> IO ()
 runCycleCheck decls = case cycleCheck declMap of
@@ -70,6 +96,15 @@ maybee = DataDeclaration "Maybe" count1 (V.fromList ctors) (PlutusData ConstrDat
         Constructor "Just" (V.singleton (Abstraction $ BoundAt Z ix0))
       ]
 
+maybeSOP :: DataDeclaration AbstractTy
+maybeSOP = DataDeclaration "MaybeSOP" count1 (V.fromList ctors) SOP
+  where
+    ctors =
+      [ Constructor "Nothing" V.empty,
+        Constructor "Just" (V.singleton (Abstraction $ BoundAt Z ix0))
+      ]
+
+
 intList :: DataDeclaration AbstractTy
 intList = DataDeclaration "IntList" count0 (V.fromList ctors) SOP
   where
@@ -81,8 +116,32 @@ intList = DataDeclaration "IntList" count0 (V.fromList ctors) SOP
     intListMore :: [ValT AbstractTy]
     intListMore = [BuiltinFlat IntegerT, Datatype "IntList" V.empty]
 
+-- DATA ENCODED MAYBE, SOP ENCODED INTLIST
+-- Maybe IntList
 encodingMismatch :: ValT AbstractTy
 encodingMismatch = Datatype "Maybe" (V.fromList [Datatype "IntList" V.empty])
+
+-- forall a. (a -> a)
+identitee :: ValT AbstractTy
+identitee = ThunkT $ Comp1 (tyvar Z ix0 :--:> ReturnT (tyvar Z ix0))
+
+-- DATA ENCODED MAYBE
+-- Maybe (Maybe (forall a. a -> a))
+badThunkArg :: ValT AbstractTy
+badThunkArg =  tyCon "Maybe" [tyCon "Maybe" [identitee]]
+
+-- SOP ENCODED MAYBE
+-- Maybe (Maybe (Maybe Integer))
+goodSOP :: ValT AbstractTy
+goodSOP = tyCon "MaybeSOP" [tyCon "MaybeSOP" [tyCon "MaybeSOP" [BuiltinFlat IntegerT]]]
+
+-- NOTE Sean 7/2/2025: We are *temporarily* forbidding thunk arguments even to SOP encoded type constructors.
+--                     This is not strictly necessary, and we can go back and change that if we have time, but it
+--                     does greatly simplify getting a proof-of-concept off the ground.
+-- SOP ENCODED MAYBE
+-- Maybe (forall a. a -> a)
+badSOPThunk :: ValT AbstractTy
+badSOPThunk = tyCon "MaybeSOP" [identitee]
 
 mutRec1 :: DataDeclaration AbstractTy
 mutRec1 = DataDeclaration "MutRec1" count0 (V.fromList ctors) SOP

--- a/test/kindcheck/Main.hs
+++ b/test/kindcheck/Main.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
 {-# HLINT ignore "Use camelCase" #-}
 module Main (main) where
 
@@ -6,22 +7,22 @@ import Covenant.DeBruijn (DeBruijn (Z))
 import Covenant.Index (count0, count1, ix0)
 import Covenant.Test (ledgerTypes)
 import Covenant.Type
-    ( AbstractTy(BoundAt),
-      BuiltinFlatT(IntegerT),
-      Constructor(Constructor),
-      DataDeclaration(DataDeclaration, OpaqueData),
-      DataEncoding(PlutusData, SOP),
-      PlutusDataStrategy(ConstrData),
-      ValT(Abstraction, BuiltinFlat, Datatype, ThunkT),
-      CompT(Comp1),
-      checkDataDecls,
-      checkEncodingArgs,
-      cycleCheck,
-      TyName,
-      tyvar,
-      tyCon,
-      CompTBody((:--:>)),
-      CompTBody(ReturnT) )
+  ( AbstractTy (BoundAt),
+    BuiltinFlatT (IntegerT),
+    CompT (Comp1),
+    CompTBody (ReturnT, (:--:>)),
+    Constructor (Constructor),
+    DataDeclaration (DataDeclaration, OpaqueData),
+    DataEncoding (PlutusData, SOP),
+    PlutusDataStrategy (ConstrData),
+    TyName,
+    ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),
+    checkDataDecls,
+    checkEncodingArgs,
+    cycleCheck,
+    tyCon,
+    tyvar,
+  )
 import Data.Map qualified as M
 import Data.Vector qualified as V
 import Optics.Core (view)
@@ -39,7 +40,7 @@ main =
       simpleEncodingMismatch,
       nestedThunkArg,
       noThunkArgsToSOPTyCons_for_now,
-      goodSOPArg 
+      goodSOPArg
     ]
 
 checkLedgerTypes :: TestTree
@@ -50,17 +51,17 @@ checkLedgerTypes =
     . foldr (\x acc -> M.insert (view #datatypeName x) x acc) M.empty
     $ ledgerTypes
 
-
 encodingCheck :: String -> [DataDeclaration AbstractTy] -> ValT AbstractTy -> TestTree
-encodingCheck testNm tyDict valT = testCase testNm  $
+encodingCheck testNm tyDict valT =
+  testCase testNm $
     either (assertFailure . show) pure $
       checkEncodingArgs (view #datatypeEncoding) (mkTyDict tyDict) valT
 
 shouldFailEncodingCheck :: String -> [DataDeclaration AbstractTy] -> ValT AbstractTy -> TestTree
-shouldFailEncodingCheck tnm tyDict valT = expectFail $  encodingCheck tnm tyDict valT
+shouldFailEncodingCheck tnm tyDict valT = expectFail $ encodingCheck tnm tyDict valT
 
 simpleEncodingMismatch :: TestTree
-simpleEncodingMismatch = shouldFailEncodingCheck  "simpleEncodingMismatch" [maybee,intList] encodingMismatch
+simpleEncodingMismatch = shouldFailEncodingCheck "simpleEncodingMismatch" [maybee, intList] encodingMismatch
 
 noThunkArgsToSOPTyCons_for_now :: TestTree
 noThunkArgsToSOPTyCons_for_now = shouldFailEncodingCheck "no thunk args to SOP tycons (for now)" [maybeSOP] badSOPThunk
@@ -104,7 +105,6 @@ maybeSOP = DataDeclaration "MaybeSOP" count1 (V.fromList ctors) SOP
         Constructor "Just" (V.singleton (Abstraction $ BoundAt Z ix0))
       ]
 
-
 intList :: DataDeclaration AbstractTy
 intList = DataDeclaration "IntList" count0 (V.fromList ctors) SOP
   where
@@ -128,7 +128,7 @@ identitee = ThunkT $ Comp1 (tyvar Z ix0 :--:> ReturnT (tyvar Z ix0))
 -- DATA ENCODED MAYBE
 -- Maybe (Maybe (forall a. a -> a))
 badThunkArg :: ValT AbstractTy
-badThunkArg =  tyCon "Maybe" [tyCon "Maybe" [identitee]]
+badThunkArg = tyCon "Maybe" [tyCon "Maybe" [identitee]]
 
 -- SOP ENCODED MAYBE
 -- Maybe (Maybe (Maybe Integer))


### PR DESCRIPTION
This: 
  - Implements a check to ensure compatibility between the encoding of a type constructor's type and its arguments. That is: It ensures that SOP encoded types and Thunks cannot be used as arguments to type constructors of data-encoded types 
  - Adds that check to the set of data declaration sanity checks (which means we run it against the ledger types in the test suite) 
  - Adds a simple shouldFail test 

@kozross Quite possibly this needs more tests, however I wanted to make sure I got this up before you ended your day so that I could get feedback on any organizational or structural issues. Suggestions for additional tests would, of course, also be welcome. 