### PR TITLE
Tests and fixes for catamorphism forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Added new error types for un-renaming
 * Modified ASG helper functions and updated tests to conform with renamer rework
 * Added support for introduction forms (ValNode stuff, ASG helper function, tests)
+* Added support for catamorphism elimination forms
 
 ## 1.1.0 -- 2025-07-11
 

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -973,6 +973,14 @@ cata rAlg rVal =
 -- 3. Force the algebra argument thunk, then try and apply the result of Step 2
 --    to that.
 --
+-- Following the steps above for our example, we would proceed as follows:
+--
+-- 1. Set `last` as `Maybe r`.
+-- 2. Cook up `List_F r (Maybe r)`. Note that this matches what the algebra
+--    expects.
+-- 3. Use the unifier with `List_F r (Maybe r) -> !Maybe r`, applying the
+--    argument `List_F r (Maybe r)` from Step 2.
+--
 -- However, if `last` is a rigid, we have an 'off by one error'. To see why,
 -- consider the form of the algebra argument:
 --

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -103,7 +103,7 @@ import Control.Monad.Reader
   )
 import Covenant.Constant (AConstant, typeConstant)
 import Covenant.Data (DatatypeInfo, mkDatatypeInfo)
-import Covenant.DeBruijn (DeBruijn, asInt)
+import Covenant.DeBruijn (DeBruijn (S, Z), asInt)
 import Covenant.Index (Count, Index, intCount, intIndex, wordCount)
 import Covenant.Internal.KindCheck (checkEncodingArgs)
 import Covenant.Internal.Ledger (ledgerTypes)
@@ -178,7 +178,7 @@ import Covenant.Internal.Term
     typeRef,
   )
 import Covenant.Internal.Type
-  ( AbstractTy,
+  ( AbstractTy (BoundAt),
     BuiltinFlatT (ByteStringT, IntegerT),
     CompT (CompT),
     CompTBody (CompTBody),
@@ -890,6 +890,11 @@ thunk i = do
 --   functor for the second argument
 -- * Second argument is not a value type
 --
+-- = Note
+--
+-- 'cata' cannot work with /non-rigid/ algebras; that is, all algebras must be
+-- functions that bind no type variables of their own.
+--
 -- @since 1.1.0
 cata ::
   forall (m :: Type -> Type).
@@ -916,17 +921,17 @@ cata rAlg rVal =
                 -- machinery can produce the type we expect with proper
                 -- concretifications.
                 unless (Vector.length bfTyArgs > 0) (throwError . CataNotAnAlgebra $ t)
-                let lastVar = Vector.last bfTyArgs
-                unless (nev NonEmpty.! 1 == lastVar) (throwError . CataNotAnAlgebra $ t)
+                let lastTyArg = Vector.last bfTyArgs
+                unless (nev NonEmpty.! 1 == lastTyArg) (throwError . CataNotAnAlgebra $ t)
                 appliedArgT <- case valT of
                   BuiltinFlat bT -> case bT of
                     ByteStringT -> do
                       unless (bfName == "ByteString_F") (throwError . CataUnsuitable algT $ valT)
-                      pure $ Datatype "ByteString_F" . Vector.singleton $ lastVar
+                      pure $ Datatype "ByteString_F" . Vector.singleton $ lastTyArg
                     IntegerT -> do
                       let isSuitableBaseFunctor = bfName == "Natural_F" || bfName == "Negative_F"
                       unless isSuitableBaseFunctor (throwError . CataUnsuitable algT $ valT)
-                      pure $ Datatype bfName . Vector.singleton $ lastVar
+                      pure $ Datatype bfName . Vector.singleton $ lastTyArg
                     _ -> throwError . CataWrongBuiltinType $ bT
                   Datatype tyName tyVars -> do
                     lookedUp <- asks (view (#datatypeInfo % at tyName))
@@ -935,7 +940,8 @@ cata rAlg rVal =
                       Just info -> case view #baseFunctor info of
                         Just (DataDeclaration actualBfName _ _ _, _) -> do
                           unless (bfName == actualBfName) (throwError . CataUnsuitable algT $ valT)
-                          pure . Datatype bfName . Vector.snoc tyVars $ lastVar
+                          let lastTyArg' = stepDownDB lastTyArg
+                          pure . Datatype bfName . Vector.snoc tyVars $ lastTyArg'
                         _ -> throwError . CataNoBaseFunctorForType $ tyName
                   _ -> throwError . CataWrongValT $ valT
                 resultT <- tryApply algT appliedArgT
@@ -946,6 +952,46 @@ cata rAlg rVal =
     t -> throwError . CataApplyToNonValT $ t
 
 -- Helpers
+
+-- Note (Koz, 13/08/2025): We need this procedure specifically for `cata`. The
+-- reason for this has to do with how we construct the 'base functor form' of
+-- the value to be torn down by the catamorphism, in order to use the
+-- unification machinery to get the type of the final result.
+--
+-- To be specific, suppose we have `<List_F r (Maybe r) -> !Maybe r>` as our algebra
+-- argument (where `r` is some rigid), and `List r` as the value to be torn
+-- down. If we assume the rigid is bound one scope away, `r`'s DeBruijn index
+-- will be `S Z` for
+-- the value to be torn down, but `S (S Z)` for the algebra argument. The way
+-- our approach works is:
+--
+-- 1. Look at the algebra argument, specifically the base functor type. Take its
+--    last type argument, which we will call `last`.
+-- 2. Determine the base functor for the value to be torn down. Cook up a new
+--    instance of the base functor type, copying all the type arguments from the
+--    value to be torn down in the same order. Then put `last` at the end.
+-- 3. Force the algebra argument thunk, then try and apply the result of Step 2
+--    to that.
+--
+-- However, if `last` is a rigid, we have an 'off by one error'. To see why,
+-- consider the form of the algebra argument:
+--
+-- `ThunkT . Comp0 $ Datatype "List_F" [tyvar (S (S Z)) ix0, ....`
+--
+-- However, `tyvar (S (S Z)) ix0` is not valid in the scope of the value to be
+-- torn down: that same rigid would have DeBruijn index `S Z` there instead.
+-- This applies the same if the tyvar is part of a datatype.
+--
+-- As we prohibit non-rigid algebras, this requires us to lower the DeBruijn
+-- index by one for our process.
+stepDownDB :: ValT AbstractTy -> ValT AbstractTy
+stepDownDB = \case
+  Abstraction (BoundAt db i) -> case db of
+    -- This is impossible, so we just return it unmodified
+    Z -> Abstraction (BoundAt db i)
+    (S db') -> Abstraction (BoundAt db' i)
+  Datatype tyName tyArgs -> Datatype tyName . fmap stepDownDB $ tyArgs
+  x -> x
 
 renameArg ::
   forall (m :: Type -> Type).

--- a/src/Covenant/Internal/Term.hs
+++ b/src/Covenant/Internal/Term.hs
@@ -130,6 +130,11 @@ data CovenantTypeError
 
     -- | Wraps an encoding argument mismatch error from KindCheck
     EncodingError (EncodingArgErr AbstractTy)
+  | -- | The first argument to a catamorphism wasn't an algebra, as
+    -- it had the wrong arity.
+    --
+    -- @since 1.2.0
+    CataAlgebraWrongArity Int
   | -- | The first argument to a catamorphism wasn't an algebra.
     --
     -- @since 1.1.0
@@ -138,6 +143,11 @@ data CovenantTypeError
     --
     -- @since 1.1.0
     CataApplyToNonValT ASGNodeType
+  | -- The algebra given to this catamorphism is not rigid (that is, its
+    -- computation type binds variables).
+    --
+    -- @since 1.2.0
+    CataNonRigidAlgebra (CompT AbstractTy)
   | -- | The second argument to a catamorphism is a builtin type, but not one
     -- we can eliminate with a catamorphism.
     --
@@ -148,6 +158,14 @@ data CovenantTypeError
     --
     -- @since 1.1.0
     CataWrongValT (ValT AbstractTy)
+  | -- | We requested a catamorphism for a type that doesn't exist.
+    --
+    -- @since 1.2.0
+    CataNoSuchType TyName
+  | -- | We requested a catamorphism for a type without a base functor.
+    --
+    -- @since 1.2.0
+    CataNoBaseFunctorForType TyName
   | -- | The provided algebra is not suitable for the given type.
     --
     -- @since 1.1.0

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -315,7 +315,7 @@ unitCataListMaybeRigid = do
   let ty =
         Comp1 $
           thunkTy
-            :--:> Datatype "List" [Datatype "Maybe" [tyvar Z ix0]]
+            :--:> Datatype "List" [tyvar Z ix0]
             :--:> ReturnT (Datatype "Maybe" [tyvar Z ix0])
   let comp = lam ty $ do
         alg <- arg Z ix0

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 module Main (main) where
@@ -7,17 +8,24 @@ import Control.Monad (guard, void)
 import Covenant.ASG
   ( ASG,
     ASGBuilder,
-    ASGNode (ACompNode),
+    ASGNode (ACompNode, AValNode, AnError),
     CompNodeInfo
       ( Builtin1,
         Builtin2,
         Builtin3
       ),
-    CovenantError (EmptyASG, TopLevelError, TopLevelValue, TypeError),
+    CovenantError
+      ( EmptyASG,
+        TopLevelError,
+        TopLevelValue,
+        TypeError
+      ),
     CovenantTypeError
       ( ApplyCompType,
         ApplyToError,
         ApplyToValType,
+        CataNoBaseFunctorForType,
+        CataNonRigidAlgebra,
         ForceCompType,
         ForceError,
         ForceNonThunk,
@@ -35,7 +43,9 @@ import Covenant.ASG
     builtin1,
     builtin2,
     builtin3,
+    cata,
     dataConstructor,
+    defaultDatatypes,
     err,
     force,
     lam,
@@ -66,6 +76,9 @@ import Covenant.Type
     CompTBody (ArgsAndResult, ReturnT, (:--:>)),
     ValT (BuiltinFlat, Datatype, ThunkT),
     arity,
+    boolT,
+    byteStringT,
+    integerT,
     tyvar,
   )
 import Covenant.Util (pattern ConsV, pattern NilV)
@@ -120,7 +133,15 @@ main =
       nothingIntro,
       justConcreteIntro,
       justRigidIntro,
-      justNothingIntro
+      justNothingIntro,
+      testGroup
+        "Catamorphisms"
+        [ testCase "Natural_F can tear down an Integer" unitCataNaturalF,
+          testCase "Negative_F can tear down an Integer" unitCataNegativeF,
+          testCase "ByteString_F can tear down a ByteString" unitCataByteStringF,
+          testCase "Non-recursive type cata should fail" unitCataMaybeF,
+          testCase "Cata with non-rigid algebra should fail" unitCataNonRigidF
+        ]
     ]
   where
     moreTests :: QuickCheckTests -> QuickCheckTests
@@ -157,6 +178,83 @@ unitThunkError = do
   case result of
     Left (TypeError _ ThunkError) -> pure ()
     _ -> assertFailure $ "Unexpected result: " <> show result
+
+-- Construct a function of type `<Natural_F Bool -> !Bool> -> Integer -> !Bool`, whose
+-- body performs a cata over its second argument using its first argument. This
+-- should compile, and type as expected.
+unitCataNaturalF :: IO ()
+unitCataNaturalF = do
+  let thunkTy = ThunkT $ Comp0 $ Datatype "Natural_F" [boolT] :--:> ReturnT boolT
+  let ty = Comp0 $ thunkTy :--:> integerT :--:> ReturnT boolT
+  let comp = lam ty $ do
+        alg <- arg Z ix0
+        x <- arg Z ix1
+        result <- cata (AnArg alg) (AnArg x)
+        pure . AnId $ result
+  withCompilationSuccessUnit comp $ matchesType ty
+
+-- Construct a function of type `<Negative_F Bool -> !Bool> -> Integer -> !Bool`, whose
+-- body performs a cata over its second argument using its first argument. This
+-- should compile, and type as expected.
+unitCataNegativeF :: IO ()
+unitCataNegativeF = do
+  let thunkTy = ThunkT $ Comp0 $ Datatype "Negative_F" [boolT] :--:> ReturnT boolT
+  let ty = Comp0 $ thunkTy :--:> integerT :--:> ReturnT boolT
+  let comp = lam ty $ do
+        alg <- arg Z ix0
+        x <- arg Z ix1
+        result <- cata (AnArg alg) (AnArg x)
+        pure . AnId $ result
+  withCompilationSuccessUnit comp $ matchesType ty
+
+-- Construct a function of type `<ByteString_F Integer -> !Integer> -> ByteString
+-- -> !Bool`, whose body performs a cata over its second argument using its
+-- first argument. This should compile, and type as expected.
+unitCataByteStringF :: IO ()
+unitCataByteStringF = do
+  let thunkTy = ThunkT $ Comp0 $ Datatype "ByteString_F" [integerT] :--:> ReturnT integerT
+  let ty = Comp0 $ thunkTy :--:> byteStringT :--:> ReturnT integerT
+  let comp = lam ty $ do
+        alg <- arg Z ix0
+        x <- arg Z ix1
+        result <- cata (AnArg alg) (AnArg x)
+        pure . AnId $ result
+  withCompilationSuccessUnit comp $ matchesType ty
+
+-- Construct a function of type `forall a . <Maybe_F a Integer -> !Integer> -> Maybe
+-- a -> !Integer`, whose body performs a cata over its second argument
+-- using its first argument. This should fail to compile, indicating that
+-- `Maybe` doesn't have a base functor.
+unitCataMaybeF :: IO ()
+unitCataMaybeF = do
+  let thunkTy = ThunkT $ Comp0 $ Datatype "Maybe_F" [tyvar (S Z) ix0, integerT] :--:> ReturnT integerT
+  let ty = Comp1 $ thunkTy :--:> Datatype "Maybe" [tyvar Z ix0] :--:> ReturnT integerT
+  let comp = lam ty $ do
+        alg <- arg Z ix0
+        x <- arg Z ix1
+        result <- cata (AnArg alg) (AnArg x)
+        pure . AnId $ result
+  withCompilationFailureUnit comp $ \case
+    TypeError _ (CataNoBaseFunctorForType tyName) -> assertEqual "" "Maybe" tyName
+    err' -> assertFailure $ "Failed with unexpected type of error: " <> show err'
+
+-- Construct a function of type `<forall a . ListF a (Maybe a) -> !Maybe a> -> List
+-- Integer -> !Maybe Integer`, whose body performs a cata over its second
+-- argument using its first argument. This should fail to compile due to a
+-- non-rigid algebra.
+unitCataNonRigidF :: IO ()
+unitCataNonRigidF = do
+  let nonRigidCompT = Comp1 $ Datatype "List_F" [tyvar Z ix0, Datatype "Maybe" [tyvar Z ix0]] :--:> ReturnT (Datatype "Maybe" [tyvar Z ix0])
+  let thunkTy = ThunkT nonRigidCompT
+  let ty = Comp0 $ thunkTy :--:> Datatype "List" [integerT] :--:> ReturnT (Datatype "Maybe" [integerT])
+  let comp = lam ty $ do
+        alg <- arg Z ix0
+        x <- arg Z ix1
+        result <- cata (AnArg alg) (AnArg x)
+        pure . AnId $ result
+  withCompilationFailureUnit comp $ \case
+    TypeError _ (CataNonRigidAlgebra t) -> assertEqual "" nonRigidCompT t
+    err' -> assertFailure $ "Failed with unexpected type of error: " <> show err'
 
 -- Properties
 
@@ -513,12 +611,12 @@ justNothingIntro = runIntroFormTest "justNothingIntro" expectedThunk $ do
     expectedThunk :: ValT AbstractTy
     expectedThunk = ThunkT expectedComp
 
+-- Helpers
+
 runIntroFormTest :: String -> ValT AbstractTy -> DebugASGBuilder (ValT AbstractTy) -> TestTree
 runIntroFormTest nm expectedTy act = testCase nm $ case debugASGBuilder tyAppTestDatatypes act of
   Left err' -> assertFailure ("ASG Error: " <> show err')
   Right actualTy -> assertEqual nm expectedTy actualTy
-
--- Helpers
 
 failWrongTypeError :: CovenantTypeError -> Property
 failWrongTypeError err' = failWithCounterExample ("Unexpected type error: " <> show err')
@@ -551,6 +649,22 @@ failUnexpectedCompNodeInfo info =
 failUnexpectedValNodeInfo :: ValNodeInfo -> Property
 failUnexpectedValNodeInfo info =
   failWithCounterExample ("Unexpected ValNodeInfo: " <> show info)
+
+withCompilationSuccessUnit :: ASGBuilder Id -> (ASG -> IO ()) -> IO ()
+withCompilationSuccessUnit comp cb = case runASGBuilder defaultDatatypes comp of
+  Left err' -> assertFailure $ "Did not compile: " <> show err'
+  Right asg -> cb asg
+
+withCompilationFailureUnit :: ASGBuilder Id -> (CovenantError -> IO ()) -> IO ()
+withCompilationFailureUnit comp cb = case runASGBuilder defaultDatatypes comp of
+  Left err' -> cb err'
+  Right asg -> assertFailure $ "Unexpected compilation success: " <> show asg
+
+matchesType :: CompT AbstractTy -> ASG -> IO ()
+matchesType expectedTy asg = case topLevelNode asg of
+  ACompNode actualTy _ -> assertEqual "" expectedTy actualTy
+  u@(AValNode _ _) -> assertFailure $ "Got a value node: " <> show u
+  AnError -> assertFailure "Got an error node"
 
 {- NOTE: Not 100% sure I won't need these
 withExpectedId :: Ref -> (Id -> Property) -> Property


### PR DESCRIPTION
This adds tests to ensure catamorphisms compile correctly. This required a few fixes to the unification machinery, as well as some additional error types.