### PR TITLE
Fix Unifier for Opaque Types 

### DIFF
--- a/src/Covenant/Internal/Unification.hs
+++ b/src/Covenant/Internal/Unification.hs
@@ -30,7 +30,7 @@ import Covenant.Internal.Type
     CompTBody (CompTBody),
     Renamed (Rigid, Unifiable, Wildcard),
     TyName,
-    ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),
+    ValT (Abstraction, BuiltinFlat, Datatype, ThunkT), DataDeclaration (OpaqueData),
   )
 import Data.Kind (Type)
 import Data.Map (Map)
@@ -122,6 +122,13 @@ lookupBBForm tn =
   lookupDatatypeInfo tn >>= \dti -> case view #bbForm dti of
     Nothing -> throwError $ NoBBForm tn
     Just bbForm -> pure bbForm
+
+-- Opaque types do not (and cannot) have a BB form, which breaks unification machinery that assumes all inhabiated types
+-- have such a form. We need to branch on the "Opacity" of a type in `expectDatatype` and this lets us do that
+isOpaqueType :: TyName -> UnifyM Bool
+isOpaqueType tn = lookupDatatypeInfo tn >>= \dti -> case view #originalDecl dti of
+  OpaqueData{} -> pure True
+  _ -> pure False
 
 -- | Given information about in-scope datatypes, a computation type, and a list
 -- of arguments (some of which may be errors), try to construct the type of the
@@ -331,18 +338,32 @@ unify expected actual =
     -- the BB form using the arguments to the actual datatype.
     -- For example, the BB form of `Maybe` is: forall a r. r -> (a -> r) -> r
     -- which, if we concretify while attempting to unify with `Maybe Int`, becomes: `forall r. r -> (Int -> r) -> r`
+    --
+    -- Opaque datatypes are a special exception and are treated analogously to Builtins: They unify only with themselves,
+    -- unifiables, or wildcards.
     expectDatatype tn args = do
-      bbForm <- lookupBBForm tn
-      bbFormConcreteE <- concretify bbForm args
-      case actual of
-        Abstraction (Rigid _ _) -> unificationError
-        Abstraction _ -> noSubUnify
-        Datatype tn' args'
-          | tn' /= tn -> unificationError
-          | otherwise -> do
-              bbFormConcreteA <- concretify bbForm args'
-              unify bbFormConcreteE bbFormConcreteA
-        _ -> unificationError
+      isOpaqueType tn >>= \case
+        False -> do
+          bbForm <- lookupBBForm tn
+          bbFormConcreteE <- concretify bbForm args
+          case actual of
+            Abstraction (Rigid _ _) -> unificationError
+            Abstraction _ -> noSubUnify
+            Datatype tn' args'
+              | tn' /= tn -> unificationError
+              | otherwise -> do
+                  bbFormConcreteA <- concretify bbForm args'
+                  unify bbFormConcreteE bbFormConcreteA
+            _ -> unificationError
+        True -> case actual of
+          Abstraction Rigid{} -> unificationError
+          Abstraction _ -> noSubUnify
+          -- Opaque datatypes cannot be parameterized, so we only need to check the TyName
+          Datatype tn' _args ->
+            if tn == tn'
+             then noSubUnify
+             else unificationError
+          _ -> unificationError
     concretify :: ValT Renamed -> Vector (ValT Renamed) -> UnifyM (ValT Renamed)
     concretify (ThunkT (CompT count (CompTBody fn))) args = fixUp $ ThunkT (CompT count (CompTBody newFn))
       where

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -153,7 +153,8 @@ import Covenant.Internal.Type
 import Covenant.Internal.Unification (checkApp)
 import Covenant.Type
   ( CompT (Comp0, CompN),
-    CompTBody (ArgsAndResult), PlutusDataConstructor (PlutusI),
+    CompTBody (ArgsAndResult),
+    PlutusDataConstructor (PlutusI),
   )
 import Covenant.Util (prettyStr)
 import Data.Coerce (coerce)

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -153,7 +153,7 @@ import Covenant.Internal.Type
 import Covenant.Internal.Unification (checkApp)
 import Covenant.Type
   ( CompT (Comp0, CompN),
-    CompTBody (ArgsAndResult),
+    CompTBody (ArgsAndResult), PlutusDataConstructor (PlutusI),
   )
 import Covenant.Util (prettyStr)
 import Data.Coerce (coerce)
@@ -371,8 +371,10 @@ failLeft = either (assertFailure . show) pure
 --
 -- @since 1.1.0
 tyAppTestDatatypes :: M.Map TyName (DatatypeInfo AbstractTy)
-tyAppTestDatatypes =
-  foldl' (\acc decl -> unsafeMkDatatypeInfo decl <> acc) primBaseFunctorInfos testDatatypes
+tyAppTestDatatypes = unsafeMkDatatypeInfos testDatatypes
+
+unsafeMkDatatypeInfos :: [DataDeclaration AbstractTy] -> M.Map TyName (DatatypeInfo AbstractTy)
+unsafeMkDatatypeInfos = foldl' (\acc decl -> unsafeMkDatatypeInfo decl <> acc) primBaseFunctorInfos
   where
     unsafeMkDatatypeInfo d = case mkDatatypeInfo d of
       Left err -> error (show err)
@@ -930,4 +932,7 @@ unitT =
       (PlutusData ConstrData)
 
 testDatatypes :: [DataDeclaration AbstractTy]
-testDatatypes = [maybeT, eitherT, unitT, pair, list]
+testDatatypes = [maybeT, eitherT, unitT, pair, list, opaqueT]
+
+opaqueT :: DataDeclaration AbstractTy
+opaqueT = OpaqueData "Opaque" (Set.fromList [PlutusI])

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -161,7 +161,9 @@ main =
         [ matchMaybe,
           matchList,
           maybeToList
-        ]
+        ],
+      testGroup "Opaque"
+        [unifyOpaque]
     ]
   where
     moreTests :: QuickCheckTests -> QuickCheckTests
@@ -785,6 +787,31 @@ maybeToList = runIntroFormTest "maybeToList" maybeToListTy $ do
 
     maybeToListTy :: ValT AbstractTy
     maybeToListTy = ThunkT maybeToListCompTy
+
+{- This tests that Opaques don't break the unifier. Arguably it should be in type-applications, but we need a bunch of
+   ASG stuff that's not imported there to construct the test, so it is here instead.
+
+   The lambda we construct has the type: Maybe Opaque -> Integer
+-}
+
+unifyOpaque :: TestTree
+unifyOpaque = runIntroFormTest "unifyOpaque" unifyOpaqueTy $ do
+  thonk <- lazyLam unifyOpaqueCompTy $ do
+    let nothingHandlerTy = Comp0 $ ReturnT (BuiltinFlat IntegerT)
+        justHandlerTy    = Comp0 $ dtype "Opaque" [] :--:> ReturnT (BuiltinFlat IntegerT)
+    nothingHandler <- lazyLam nothingHandlerTy $ (AnId <$> lit (AnInteger 0))
+    justHandler <- lazyLam justHandlerTy $ (AnId <$> lit (AnInteger 1))
+    scrutinee <- AnArg <$> arg Z ix0
+    AnId <$> match scrutinee (AnId <$> Vector.fromList [justHandler,nothingHandler])
+  typeIdTest thonk 
+ where
+   unifyOpaqueCompTy :: CompT AbstractTy
+   unifyOpaqueCompTy = Comp0 $ dtype "Maybe" [dtype "Opaque" []] :--:> ReturnT (BuiltinFlat IntegerT)
+
+   unifyOpaqueTy :: ValT AbstractTy
+   unifyOpaqueTy = ThunkT unifyOpaqueCompTy
+
+
 
 -- Helpers
 

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -162,7 +162,8 @@ main =
           matchList,
           maybeToList
         ],
-      testGroup "Opaque"
+      testGroup
+        "Opaque"
         [unifyOpaque]
     ]
   where
@@ -798,20 +799,18 @@ unifyOpaque :: TestTree
 unifyOpaque = runIntroFormTest "unifyOpaque" unifyOpaqueTy $ do
   thonk <- lazyLam unifyOpaqueCompTy $ do
     let nothingHandlerTy = Comp0 $ ReturnT (BuiltinFlat IntegerT)
-        justHandlerTy    = Comp0 $ dtype "Opaque" [] :--:> ReturnT (BuiltinFlat IntegerT)
+        justHandlerTy = Comp0 $ dtype "Opaque" [] :--:> ReturnT (BuiltinFlat IntegerT)
     nothingHandler <- lazyLam nothingHandlerTy $ (AnId <$> lit (AnInteger 0))
     justHandler <- lazyLam justHandlerTy $ (AnId <$> lit (AnInteger 1))
     scrutinee <- AnArg <$> arg Z ix0
-    AnId <$> match scrutinee (AnId <$> Vector.fromList [justHandler,nothingHandler])
-  typeIdTest thonk 
- where
-   unifyOpaqueCompTy :: CompT AbstractTy
-   unifyOpaqueCompTy = Comp0 $ dtype "Maybe" [dtype "Opaque" []] :--:> ReturnT (BuiltinFlat IntegerT)
+    AnId <$> match scrutinee (AnId <$> Vector.fromList [justHandler, nothingHandler])
+  typeIdTest thonk
+  where
+    unifyOpaqueCompTy :: CompT AbstractTy
+    unifyOpaqueCompTy = Comp0 $ dtype "Maybe" [dtype "Opaque" []] :--:> ReturnT (BuiltinFlat IntegerT)
 
-   unifyOpaqueTy :: ValT AbstractTy
-   unifyOpaqueTy = ThunkT unifyOpaqueCompTy
-
-
+    unifyOpaqueTy :: ValT AbstractTy
+    unifyOpaqueTy = ThunkT unifyOpaqueCompTy
 
 -- Helpers
 


### PR DESCRIPTION
Modified unification machinery to treat opaque types analogously to builtins, added a test. 