### PR TITLE
Opaque Match Fix

### DIFF
--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -1065,6 +1065,24 @@ cata rAlg rVal =
 -- All handlers must be thunks, and must all return the same (concrete) result.
 -- Polymorphic \'handlers\' (that is, thunks whose computation binds type
 -- variables of its own) will fail to compile.
+-- NOTE: Opaque the handlers for an opaque type must follow the order:
+--  [ PlutusI,
+--    PlutusB,
+--    PlutusConstr,
+--    PlutusMap,
+--    PlutusList
+--  ]
+--
+--  Where types not included in the provided constructors to the Opaque declaration are omitted.
+--
+--  Furthermore, the handlers for opaque constructors operate on the unwrapped arguments to
+--  their respective PlutusData constructor. That is, for some result type 'r', the handlers for a
+--  an opaque type which uses all the constructors should have the types:
+--    PlutusI :: Integer -> r
+--    PlutusB :: ByteString -> r
+--    PlutusConstr :: Integer -> [Data] -> r
+--    PlutusMap :: [(Integer,Data)] -> r
+--    PlutusList :: [Data] -> r
 --
 -- @since 1.2.0
 match ::

--- a/src/Covenant/Data.hs
+++ b/src/Covenant/Data.hs
@@ -46,11 +46,12 @@ import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.Reader (MonadReader (ask, local), MonadTrans (lift), Reader, runReader)
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Covenant.DeBruijn (DeBruijn (S, Z), asInt)
-import Covenant.Index (Count, Index, count0, intCount, intIndex)
+import Covenant.Index (Count, Index, count0, intCount, intIndex, ix0)
 import Covenant.Internal.PrettyPrint (ScopeBoundary (ScopeBoundary))
-import Covenant.Internal.Strategy (DataEncoding (SOP))
+import Covenant.Internal.Strategy (DataEncoding (SOP), PlutusDataConstructor (PlutusConstr, PlutusI, PlutusB, PlutusMap, PlutusList))
 import Covenant.Internal.Type
   ( AbstractTy (BoundAt),
+    BuiltinFlatT (IntegerT, ByteStringT),
     CompT (CompT),
     CompTBody (CompTBody),
     Constructor (Constructor),
@@ -62,6 +63,8 @@ import Covenant.Internal.Type
     naturalBaseFunctor,
     negativeBaseFunctor,
   )
+import Covenant.Type (CompT(Comp0, Comp1),
+                      CompTBody ((:--:>), ReturnT), tyvar)
 import Data.Bitraversable (bisequence)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
@@ -408,7 +411,33 @@ incAbstractionDB = mapValT $ \case
 
 -- Only returns `Nothing` if there are no Constructors or the type is Opaque
 mkBBF' :: DataDeclaration AbstractTy -> ExceptT BBFError Maybe (ValT AbstractTy)
-mkBBF' OpaqueData {} = lift Nothing
+mkBBF' (OpaqueData _ ctorsSet) = do
+  let bbfFunArgs = map mkOpaqueFn (Set.toList ctorsSet)
+  case NEV.fromList bbfFunArgs of
+    Nothing -> error "No ctors for opaque. If this happens it means we didn't run the kind checker."
+    Just fn -> lift . Just . ThunkT . Comp1 . CompTBody $ NEV.snoc fn (tyvar Z ix0)
+ where
+    -- `r` as it appears in the thunks
+    r :: ValT AbstractTy
+    r = Abstraction (BoundAt (S Z) ix0)
+    helper :: ValT AbstractTy -> ValT AbstractTy
+    helper arg = ThunkT . Comp0 $ arg :--:> ReturnT r
+    pList :: V.Vector (ValT AbstractTy) -> ValT AbstractTy
+    pList  = Datatype "List"
+    pData :: ValT AbstractTy
+    pData = Datatype "Data" mempty
+    pPair :: ValT AbstractTy -> ValT AbstractTy -> ValT AbstractTy
+    pPair a b = Datatype "Pair" $ V.fromList [a,b]
+    mkOpaqueFn :: PlutusDataConstructor -> ValT AbstractTy
+    mkOpaqueFn = \case
+      PlutusI -> helper $ BuiltinFlat IntegerT
+      PlutusB -> helper $ BuiltinFlat ByteStringT
+      PlutusConstr ->
+        ThunkT . Comp0 $ BuiltinFlat IntegerT
+                         :--:> pList (V.fromList [pData])
+                         :--:> ReturnT r
+      PlutusList -> helper (pList (V.singleton pData))
+      PlutusMap -> helper (pList (V.singleton (pPair pData pData)))
 mkBBF' (DataDeclaration tn numVars ctors _)
   | V.null ctors = lift Nothing
   | otherwise = do

--- a/src/Covenant/Internal/Unification.hs
+++ b/src/Covenant/Internal/Unification.hs
@@ -156,7 +156,7 @@ checkApp' f@(CompT _ (CompTBody xs)) ys = do
   when (numArgsActual < numArgsExpected) $
     throwError $
       InsufficientArgs numArgsActual f ys
-  when (numArgsExpected > numArgsActual) $
+  when (numArgsActual > numArgsExpected) $
     throwError $
       ExcessArgs f (Vector.fromList ys)
   go curr (Vector.toList rest) ys

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -131,7 +131,7 @@ import Covenant.Internal.Rename
   )
 import Covenant.Internal.Strategy
   ( DataEncoding (PlutusData, SOP),
-    PlutusDataConstructor (PlutusI),
+    PlutusDataConstructor (PlutusI, PlutusB),
     PlutusDataStrategy (ConstrData),
   )
 import Covenant.Internal.Term (ASGNodeType (CompNodeType, ValNodeType), typeId)
@@ -962,7 +962,7 @@ conformance_Void :: DataDeclaration AbstractTy
 conformance_Void = mkDecl $ Decl "Void" count0 [] SOP
 
 conformance_OpaqueFoo :: DataDeclaration AbstractTy
-conformance_OpaqueFoo = OpaqueData "Foo" (Set.fromList [PlutusI])
+conformance_OpaqueFoo = OpaqueData "Foo" (Set.fromList [PlutusI, PlutusB])
 
 conformance_Maybe_SOP :: DataDeclaration AbstractTy
 conformance_Maybe_SOP =

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -131,7 +131,7 @@ import Covenant.Internal.Rename
   )
 import Covenant.Internal.Strategy
   ( DataEncoding (PlutusData, SOP),
-    PlutusDataConstructor (PlutusI, PlutusB),
+    PlutusDataConstructor (PlutusB, PlutusI),
     PlutusDataStrategy (ConstrData),
   )
 import Covenant.Internal.Term (ASGNodeType (CompNodeType, ValNodeType), typeId)

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -80,7 +80,7 @@ import Covenant.Test
   )
 import Covenant.Type
   ( AbstractTy,
-    BuiltinFlatT (IntegerT, UnitT, ByteStringT),
+    BuiltinFlatT (ByteStringT, IntegerT, UnitT),
     CompT (Comp0, Comp1, Comp2, CompN),
     CompTBody (ArgsAndResult, ReturnT, (:--:>)),
     ValT (BuiltinFlat, Datatype, ThunkT),
@@ -822,11 +822,12 @@ matchOpaque = runIntroFormTest "matchOpaque" matchOpaqueTy $ do
     scrutinee <- AnArg <$> arg Z ix0
     AnId <$> match scrutinee (AnId <$> Vector.fromList [iHandler, bHandler])
   typeIdTest thonk
- where
-   matchOpaqueCompTy :: CompT AbstractTy
-   matchOpaqueCompTy = Comp0 $ dtype "Foo" [] :--:> ReturnT (BuiltinFlat IntegerT)
-   matchOpaqueTy :: ValT AbstractTy
-   matchOpaqueTy = ThunkT matchOpaqueCompTy
+  where
+    matchOpaqueCompTy :: CompT AbstractTy
+    matchOpaqueCompTy = Comp0 $ dtype "Foo" [] :--:> ReturnT (BuiltinFlat IntegerT)
+    matchOpaqueTy :: ValT AbstractTy
+    matchOpaqueTy = ThunkT matchOpaqueCompTy
+
 -- Helpers
 
 runIntroFormTest :: String -> ValT AbstractTy -> DebugASGBuilder (ValT AbstractTy) -> TestTree

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -80,7 +80,7 @@ import Covenant.Test
   )
 import Covenant.Type
   ( AbstractTy,
-    BuiltinFlatT (IntegerT, UnitT),
+    BuiltinFlatT (IntegerT, UnitT, ByteStringT),
     CompT (Comp0, Comp1, Comp2, CompN),
     CompTBody (ArgsAndResult, ReturnT, (:--:>)),
     ValT (BuiltinFlat, Datatype, ThunkT),
@@ -164,7 +164,8 @@ main =
         ],
       testGroup
         "Opaque"
-        [unifyOpaque]
+        [unifyOpaque],
+      testGroup "matchOpaque" [matchOpaque]
     ]
   where
     moreTests :: QuickCheckTests -> QuickCheckTests
@@ -811,6 +812,21 @@ unifyOpaque = runIntroFormTest "unifyOpaque" unifyOpaqueTy $ do
     unifyOpaqueTy :: ValT AbstractTy
     unifyOpaqueTy = ThunkT unifyOpaqueCompTy
 
+matchOpaque :: TestTree
+matchOpaque = runIntroFormTest "matchOpaque" matchOpaqueTy $ do
+  thonk <- lazyLam matchOpaqueCompTy $ do
+    let iHandlerTy = Comp0 $ BuiltinFlat IntegerT :--:> ReturnT (BuiltinFlat IntegerT)
+        bHandlerTy = Comp0 $ BuiltinFlat ByteStringT :--:> ReturnT (BuiltinFlat IntegerT)
+    iHandler <- lazyLam iHandlerTy $ AnId <$> lit (AnInteger 0)
+    bHandler <- lazyLam bHandlerTy $ AnId <$> lit (AnInteger 1)
+    scrutinee <- AnArg <$> arg Z ix0
+    AnId <$> match scrutinee (AnId <$> Vector.fromList [iHandler, bHandler])
+  typeIdTest thonk
+ where
+   matchOpaqueCompTy :: CompT AbstractTy
+   matchOpaqueCompTy = Comp0 $ dtype "Foo" [] :--:> ReturnT (BuiltinFlat IntegerT)
+   matchOpaqueTy :: ValT AbstractTy
+   matchOpaqueTy = ThunkT matchOpaqueCompTy
 -- Helpers
 
 runIntroFormTest :: String -> ValT AbstractTy -> DebugASGBuilder (ValT AbstractTy) -> TestTree

--- a/test/type-applications/Main.hs
+++ b/test/type-applications/Main.hs
@@ -135,7 +135,7 @@ propTooManyArgs = forAllShrink gen shr $ \excessArgs ->
       case renamedExcessArgs of
         [] -> discard -- should be impossible
         arg : extraArgs ->
-          let expected = Left . ExcessArgs renamedIdT . Vector.fromList . fmap Just $ (arg:extraArgs)
+          let expected = Left . ExcessArgs renamedIdT . Vector.fromList . fmap Just $ (arg : extraArgs)
               actual = checkApp M.empty renamedIdT (fmap Just renamedExcessArgs)
            in expected === actual
   where

--- a/test/type-applications/Main.hs
+++ b/test/type-applications/Main.hs
@@ -134,8 +134,8 @@ propTooManyArgs = forAllShrink gen shr $ \excessArgs ->
     withRenamedVals mempty excessArgs $ \renamedExcessArgs ->
       case renamedExcessArgs of
         [] -> discard -- should be impossible
-        _ : extraArgs ->
-          let expected = Left . ExcessArgs renamedIdT . Vector.fromList . fmap Just $ extraArgs
+        arg : extraArgs ->
+          let expected = Left . ExcessArgs renamedIdT . Vector.fromList . fmap Just $ (arg:extraArgs)
               actual = checkApp M.empty renamedIdT (fmap Just renamedExcessArgs)
            in expected === actual
   where


### PR DESCRIPTION
- Adds a BBF Generator for Opaque Types (This is, by itself, enough to fix the problem and facilitate matchings) 
- Adds a test for that change 
- Change to the kind checker to ensure we explicitly forbid Opaques w/ no declared constructors 
- Fixed a bug in the unifier that would cause incorrect `ExcessArgs` errors 
- Updated a test to conform w/ unifier fix 