### PR TITLE
Fix Concretification/Unification Issue in `app`

### DIFF
--- a/covenant.cabal
+++ b/covenant.cabal
@@ -22,17 +22,17 @@ extra-source-files:
 -- Common sections
 common lang
   ghc-options:
-    -Wall
-    -Wcompat
-    -Wredundant-bang-patterns
-    -Wredundant-strictness-flags
-    -Wmissing-deriving-strategies
-    -Woperator-whitespace
-    -Wambiguous-fields
-    -Wmisplaced-pragmas
-    -Wmissing-export-lists
-    -Wmissing-import-lists
-    -Wunused-imports
+    -- -Wall
+    -- -Wcompat
+    -- -Wredundant-bang-patterns
+    -- -Wredundant-strictness-flags
+    -- -Wmissing-deriving-strategies
+    -- -Woperator-whitespace
+    -- -Wambiguous-fields
+    -- -Wmisplaced-pragmas
+    -- -Wmissing-export-lists
+    -- -Wmissing-import-lists
+    -- -Wunused-imports
 
   default-extensions:
     BangPatterns

--- a/covenant.cabal
+++ b/covenant.cabal
@@ -22,17 +22,17 @@ extra-source-files:
 -- Common sections
 common lang
   ghc-options:
-    -- -Wall
-    -- -Wcompat
-    -- -Wredundant-bang-patterns
-    -- -Wredundant-strictness-flags
-    -- -Wmissing-deriving-strategies
-    -- -Woperator-whitespace
-    -- -Wambiguous-fields
-    -- -Wmisplaced-pragmas
-    -- -Wmissing-export-lists
-    -- -Wmissing-import-lists
-    -- -Wunused-imports
+    -Wall
+    -Wcompat
+    -Wredundant-bang-patterns
+    -Wredundant-strictness-flags
+    -Wmissing-deriving-strategies
+    -Woperator-whitespace
+    -Wambiguous-fields
+    -Wmisplaced-pragmas
+    -Wmissing-export-lists
+    -Wmissing-import-lists
+    -Wunused-imports
 
   default-extensions:
     BangPatterns

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -297,7 +297,6 @@ import Optics.Core
     _1,
     _2,
   )
-import Debug.Trace (traceM)
 
 -- | A read-only pattern for exposing the internals of an 'Id'.
 --
@@ -784,13 +783,7 @@ app fId argRefs instTys = do
             let concretifiedFT = concretifyFT renamedFT renamedArgs
             instantiatedFT <- instantiate subs concretifiedFT
             tyDict <- asks (view #datatypeInfo)
-            let appTrace = "\n\nAPP\n  FN: " <> show renamedFT
-                           <> "\n  ARGS: " <> show renamedArgs
-                           <> "\n  CONCRETE: " <> show instantiatedFT
-                           <> "\n\n"
-            traceM appTrace
             result <- either (throwError . UnificationError) pure $ checkApp tyDict instantiatedFT (Vector.toList renamedArgs)
-            traceM $ "  RESULT: " <> show result 
             restored <- undoRenameM result
             unRenamedFnTy <- undoRenameCompT instantiatedFT
             checkEncodingWithInfo tyDict restored
@@ -821,7 +814,6 @@ app fId argRefs instTys = do
         []
 
     instantiate :: [(Index "tyvar", ValT Renamed)] -> CompT Renamed -> m (CompT Renamed)
-    instantiate [] fn = pure fn
     instantiate subs fn = do
       instantiated <- liftUnifyM . fixUp $ foldr (\(i, t) f -> substitute i t f) (ThunkT fn) subs
       case instantiated of

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -236,11 +236,12 @@ import Covenant.Internal.Unification
       ),
     UnifyM,
     checkApp,
+    concretifyFT,
     fixUp,
     reconcile,
     runUnifyM,
     substitute,
-    unify, concretifyFT,
+    unify,
   )
 import Covenant.Prim
   ( OneArgFunc,
@@ -757,13 +758,13 @@ err = refTo AnError
 -- * \'Use this type variable in our scope\', specified as 'Data.Wedge.Here'.
 -- * \'Use this concrete type\', specified as 'Data.Wedge.There'.
 --
--- *** IMPORTANT ***
+-- = IMPORTANT
 -- The *only* purpose of explicit type application arguments is to instantiate a tyvar in the result which is
 -- not determined by any argument. These variables are instantiated after every other argument has been concretified.
 --
 -- For example, if you have a function
---   `f :: forall a b c. (a -> b) -> (b -> a) -> b -> Either a c`
--- Then you will need to supply *ONE* explicit type application to concretify `c`.
+--   @f :: forall a b c. (a -> b) -> (b -> a) -> b -> Either a c@
+-- Then you will need to supply *ONE* explicit type application to concretify @c@.
 -- @since wip
 app ::
   forall (m :: Type -> Type).

--- a/src/Covenant/ASG.hs
+++ b/src/Covenant/ASG.hs
@@ -757,6 +757,13 @@ err = refTo AnError
 -- * \'Use this type variable in our scope\', specified as 'Data.Wedge.Here'.
 -- * \'Use this concrete type\', specified as 'Data.Wedge.There'.
 --
+-- *** IMPORTANT ***
+-- The *only* purpose of explicit type application arguments is to instantiate a tyvar in the result which is
+-- not determined by any argument. These variables are instantiated after every other argument has been concretified.
+--
+-- For example, if you have a function
+--   `f :: forall a b c. (a -> b) -> (b -> a) -> b -> Either a c`
+-- Then you will need to supply *ONE* explicit type application to concretify `c`.
 -- @since wip
 app ::
   forall (m :: Type -> Type).
@@ -773,7 +780,7 @@ app fId argRefs instTys = do
   case lookedUp of
     CompNodeType fT -> case runRenameM scopeInfo . renameCompT $ fT of
       Left err' -> throwError . RenameFunctionFailed fT $ err'
-      Right renamedFT@(CompT count fBody) -> do
+      Right renamedFT@(CompT count _) -> do
         let numInstantiations = Vector.length instTys
             numVars = review intCount count
         if numInstantiations /= numVars

--- a/src/Covenant/Internal/Unification.hs
+++ b/src/Covenant/Internal/Unification.hs
@@ -15,6 +15,10 @@ module Covenant.Internal.Unification
   )
 where
 
+#if __GLASGOW_HASKELL__==908
+import Data.Foldable (foldl')
+#endif
+
 import Control.Applicative (Alternative ((<|>)))
 import Control.Monad (foldM, unless, when)
 import Control.Monad.Except (MonadError, catchError, throwError)
@@ -33,7 +37,6 @@ import Covenant.Internal.Type
     ValT (Abstraction, BuiltinFlat, Datatype, ThunkT),
   )
 import Covenant.Type (CompT (CompN), CompTBody (ArgsAndResult))
-import Data.Foldable (foldl')
 import Data.Kind (Type)
 import Data.Map (Map)
 import Data.Map qualified as M

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -139,7 +139,6 @@ import Covenant.Internal.Term
   ( ASGNodeType (CompNodeType, ValNodeType),
     Arg (UnsafeMkArg),
     Id (UnsafeMkId),
-    Ref,
     typeId,
   )
 import Covenant.Internal.Type

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE OverloadedLists #-}
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -70,6 +71,10 @@ module Covenant.Test
     typeIdTest,
     Arg (UnsafeMkArg),
     Id (UnsafeMkId),
+
+    -- ** Exports for codegen tests
+    concretifyMinimalBuilder,
+    concretifyMegaTest
   )
 where
 
@@ -90,14 +95,14 @@ import Control.Monad.State.Strict
   )
 import Control.Monad.Trans (MonadTrans (lift))
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
-import Covenant.ASG (ASGEnv (ASGEnv), ASGNode, CovenantError (TypeError), CovenantTypeError, Id, ScopeInfo (ScopeInfo))
+import Covenant.ASG (ASGEnv (ASGEnv), ASGNode, CovenantError (TypeError), CovenantTypeError, Id, ScopeInfo (ScopeInfo), ASGBuilder, lam, dtype, arg, ctor', app', lazyLam, lit, match, thunk, builtin3, boundTyVar, force, ctor, builtin2)
 import Covenant.Data
   ( DatatypeInfo,
     mkDatatypeInfo,
     noPhantomTyVars,
     primBaseFunctorInfos,
   )
-import Covenant.DeBruijn (DeBruijn (Z), asInt)
+import Covenant.DeBruijn (DeBruijn (Z, S), asInt)
 import Covenant.Index
   ( Count,
     count0,
@@ -106,7 +111,7 @@ import Covenant.Index
     intCount,
     intIndex,
     ix0,
-    ix1,
+    ix1, ix2, ix3,
   )
 import Covenant.Internal.KindCheck
   ( checkDataDecls,
@@ -142,7 +147,7 @@ import Covenant.Internal.Term
   ( ASGNodeType (CompNodeType, ValNodeType),
     Arg (UnsafeMkArg),
     Id (UnsafeMkId),
-    typeId,
+    typeId, Ref,
   )
 import Covenant.Internal.Type
   ( AbstractTy (BoundAt),
@@ -165,9 +170,9 @@ import Covenant.Internal.Type
   )
 import Covenant.Internal.Unification (checkApp)
 import Covenant.Type
-  ( CompT (Comp0, CompN),
-    CompTBody (ArgsAndResult),
-    tyvar,
+  ( CompT (Comp0, CompN, Comp2, Comp1),
+    CompTBody (ArgsAndResult, (:--:>), ReturnT),
+    tyvar, boolT,
   )
 import Covenant.Util (prettyStr)
 import Data.Coerce (coerce)
@@ -213,6 +218,12 @@ import Test.QuickCheck.GenT qualified as GT
 import Test.QuickCheck.Instances.Containers ()
 import Test.QuickCheck.Instances.Vector ()
 import Test.Tasty.HUnit (assertFailure)
+import Covenant.Index (Index)
+import Covenant.ASG (Ref(AnArg))
+import Covenant.ASG (Ref(AnId))
+import Covenant.Constant (AConstant(AnInteger, ABoolean))
+import Covenant.Prim (ThreeArgFunc(IfThenElse), TwoArgFunc (EqualsInteger))
+import Data.Wedge (Wedge(Here))
 
 -- | Wrapper for 'ValT' to provide an 'Arbitrary' instance to generate only
 -- value types without any type variables.
@@ -994,3 +1005,176 @@ conformance_Result =
         Ctor "OK" [tyvar Z ix1]
       ]
       (PlutusData ConstrData)
+
+-- These are canned tests for concretification. They do double duty as tests for
+-- part of the code generator, so we put them here to avoid having to duplicate them across
+-- repositories.
+
+intT :: ValT AbstractTy
+intT = BuiltinFlat IntegerT
+
+mkMaybeT :: ValT AbstractTy -> ValT AbstractTy
+mkMaybeT t = dtype "Maybe" [t]
+
+ix4 :: forall s. Index s
+ix4 = fromJust $ preview intIndex 4
+
+thunk0 :: forall (a :: Type). CompTBody a -> ValT a
+thunk0 = ThunkT . Comp0
+
+(#==) :: Ref -> Ref -> ASGBuilder Ref
+x #== y = do
+  equals <- builtin2 EqualsInteger
+  AnId <$> app' equals [x, y]
+
+-- This is the minimal example, largely for testing that our fix to the concretification/unification glitch
+-- in this repo works.
+concretifyMinimalBuilder :: ASGBuilder Id
+concretifyMinimalBuilder = lam topLevelTy body
+  where
+    topLevelTy :: CompT AbstractTy
+    topLevelTy = Comp0 $ intT :--:> boolT :--:> ReturnT intT
+
+    body :: ASGBuilder Ref
+    body = do
+      intArg <- AnArg <$> arg Z ix0
+      boolArg <- AnArg <$> arg Z ix1
+      fElim <- fPolyOneElimMinimal
+      maybeInt <- ctor' "Maybe" "Just" [intArg]
+      AnId <$> app' fElim [AnId maybeInt,boolArg]
+
+    fPolyOneElimMinimal :: ASGBuilder Id
+    fPolyOneElimMinimal =  lam fPolyOneElimTy $ do
+      maybeA <- AnArg <$> arg Z ix0
+      nothingHandler <- lazyLam (Comp0 $ ReturnT intT) $ do
+        AnId <$> lit (AnInteger 0)
+      justHandler <- lazyLam (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT intT) $ do
+        AnId <$> lit (AnInteger 0)
+      AnId <$> match maybeA [AnId justHandler,AnId nothingHandler]
+     where
+       fPolyOneElimTy :: CompT AbstractTy
+       fPolyOneElimTy = Comp2 $ -- forall a b.
+                        mkMaybeT (tyvar Z ix0) -- Maybe a
+                        :--:> tyvar Z ix1 -- b
+                        :--:> ReturnT intT -- Int
+
+-- This is a torture test example. We'll use it here since we have it and it's relevant, but it's largely
+-- designed for a test in the code generator.
+concretifyMegaTest :: ASGBuilder Id
+concretifyMegaTest = lam topLevelTy body
+  where
+    body :: ASGBuilder Ref
+    body = do
+      intArg <- AnArg <$> arg Z ix0
+      boolArg <- AnArg <$> arg Z ix1
+      idF <- AnId <$> (thunk =<< identitee)
+      fmono <- AnId <$> (thunk =<< fMono)
+      gmono <- AnId <$> (thunk =<< gMono)
+      mConst <- AnId <$> (thunk =<< monoConst)
+      fIntro <- fPolyOneIntro
+      fElim <- fPolyOneElim
+      introApplied <- app' fIntro [fmono,mConst,gmono,intArg,boolArg]
+      -- REVIEW @Koz: You said that a fully polymorphic identity function *should not work* as the second arg here, but it does work?
+      AnId <$> app' fElim [AnId introApplied,idF,boolArg,fmono]
+
+    ifte ::  ASGBuilder Id
+    ifte  = lam (Comp1 $ boolT :--:> tyvar Z ix0 :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
+      cond <- AnArg <$> arg Z ix0
+      t    <- AnArg <$> arg Z ix1
+      f    <- AnArg <$> arg Z ix2
+      ifThen <- builtin3 IfThenElse
+      AnId <$> app' ifThen [cond,t,f]
+
+
+    -- NOTE: I wonder what happens if we tried to define id and monoConst in terms of each other?
+    --       Like if we do it so that we get infinite mutual recursion. I should probably *try*
+    --       to compile something like that just to see whether it explodes.
+    identitee :: ASGBuilder Id
+    identitee = lam (Comp1 $ tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
+      -- Not how you would typically implement `id` lol
+      mConst <- monoConst
+      x <- AnArg <$> arg Z ix0
+      -- Might not need the ty app?
+      AnId <$> app' mConst [x,x] -- [Here tyX]
+
+    -- forall a. a -> a -> a
+    monoConst :: ASGBuilder Id
+    monoConst = lam (Comp1 $ tyvar Z ix0 :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
+      AnArg <$> arg Z ix1
+
+    topLevelTy :: CompT AbstractTy
+    topLevelTy = Comp0 $ intT :--:> boolT :--:> ReturnT intT
+
+    fPolyOneElim :: ASGBuilder Id
+    fPolyOneElim = lam fPolyOneElimTy $ do
+      zero <- AnId <$> lit (AnInteger 0)
+      maybeA <- AnArg <$> arg Z ix0
+      nothingHandler <- lazyLam (Comp0 $ ReturnT intT) $ do
+        mConst <- monoConst
+        b <- AnArg <$> arg (S Z) ix2
+        bToInt <- force . AnArg =<< arg (S Z) ix3
+        x <- AnId <$> app' bToInt [b]
+        AnId <$> app' mConst [zero,x]
+      justHandler <- lazyLam (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT intT) $ do
+        aToInt <- force . AnArg =<< arg (S Z) ix1
+        a <- AnArg <$> arg Z ix0
+        AnId <$> app' aToInt [a]
+      AnId <$> match maybeA [AnId justHandler, AnId nothingHandler] -- ,AnId justHandler]
+     where
+       fPolyOneElimTy :: CompT AbstractTy
+       fPolyOneElimTy = Comp2 $ -- forall a b.
+                        mkMaybeT (tyvar Z ix0) -- Maybe a
+                        :--:> thunk0 (tyvar (S Z) ix0 :--:> ReturnT intT) -- (a -> Int)
+                        :--:> tyvar Z ix1 -- b
+                        :--:> thunk0 (tyvar (S Z) ix1 :--:> ReturnT intT) -- (b -> Int)
+                        :--:> ReturnT intT -- Int
+
+
+    fPolyOneIntro :: ASGBuilder Id
+    fPolyOneIntro = lam fPolyOneIntroTy $ do
+      fba <- force . AnArg =<< arg Z ix0
+      faa <- force . AnArg =<< arg Z ix1
+      predA <- force . AnArg =<< arg Z ix2
+      a <- AnArg <$> arg Z ix3
+      b <- AnArg <$> arg Z ix4
+      -- let ba = fba (monoConst b b)
+      mConst <- monoConst
+      fbaArg <- AnId <$> app' mConst [b,b]
+      ba <- AnId <$> app' fba [fbaArg]
+      -- let aaa = monoConst a (faa a ba)
+      aaaArg <- AnId <$> app' faa [a,ba]
+      aaa <- AnId <$> app' mConst [a,aaaArg]
+      -- if (predA aaa) then Nothing else Just aaa
+      tvA <- boundTyVar Z ix0
+      nothing <- ctor "Maybe" "Nothing" [] [Here tvA]
+      justAAA <- ctor' "Maybe" "Just" [aaa]
+      ifThen <- ifte
+      cond <- app' predA [aaa]
+      AnId <$> app' ifThen [AnId cond,AnId nothing,AnId justAAA]
+     where
+       fPolyOneIntroTy :: CompT AbstractTy
+       fPolyOneIntroTy = Comp2 $ -- forall a b.
+                         ThunkT (Comp0 $ tyvar (S Z) ix1 :--:> ReturnT (tyvar (S Z) ix0)) -- (b -> a)
+                         :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> tyvar (S Z) ix0 :--:> ReturnT (tyvar (S Z) ix0)) -- (a -> a -> a)
+                         :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT boolT) -- (a -> Bool)
+                         :--:> tyvar Z ix0 -- a
+                         :--:> tyvar Z ix1 -- b
+                         :--:> ReturnT (mkMaybeT (tyvar Z ix0)) -- Maybe a
+
+    fMono :: ASGBuilder Id
+    fMono = lam (Comp0 $ boolT :--:> ReturnT intT) $ do
+          aBool <- AnArg <$> arg Z ix0
+          one <- AnId <$> lit (AnInteger 1)
+          zero <- AnId <$> lit (AnInteger 0)
+          ifThen <- ifte
+          AnId <$> app' ifThen [aBool,one,zero] 
+
+    gMono :: ASGBuilder Id
+    gMono = lam (Comp0 $ intT :--:> ReturnT boolT) $ do
+          anInt <- AnArg <$> arg Z ix0
+          zero <- AnId <$> lit (AnInteger 0)
+          cond <- anInt #== zero
+          ifThen <- ifte
+          false <- AnId <$> lit (ABoolean False)
+          troo  <- AnId <$> lit (ABoolean True)
+          AnId <$> app' ifThen [cond,false,troo]

--- a/src/Covenant/Test.hs
+++ b/src/Covenant/Test.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PolyKinds #-}
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -74,7 +74,7 @@ module Covenant.Test
 
     -- ** Exports for codegen tests
     concretifyMinimalBuilder,
-    concretifyMegaTest
+    concretifyMegaTest,
   )
 where
 
@@ -95,24 +95,16 @@ import Control.Monad.State.Strict
   )
 import Control.Monad.Trans (MonadTrans (lift))
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
-import Covenant.ASG (ASGEnv (ASGEnv), ASGNode, CovenantError (TypeError), CovenantTypeError, Id, ScopeInfo (ScopeInfo), ASGBuilder, lam, dtype, arg, ctor', app', lazyLam, lit, match, thunk, builtin3, boundTyVar, force, ctor, builtin2)
+import Covenant.ASG (ASGBuilder, ASGEnv (ASGEnv), ASGNode, CovenantError (TypeError), CovenantTypeError, Id, Ref (AnArg, AnId), ScopeInfo (ScopeInfo), app', arg, boundTyVar, builtin2, builtin3, ctor, ctor', dtype, force, lam, lazyLam, lit, match, thunk)
+import Covenant.Constant (AConstant (ABoolean, AnInteger))
 import Covenant.Data
   ( DatatypeInfo,
     mkDatatypeInfo,
     noPhantomTyVars,
     primBaseFunctorInfos,
   )
-import Covenant.DeBruijn (DeBruijn (Z, S), asInt)
-import Covenant.Index
-  ( Count,
-    count0,
-    count1,
-    count2,
-    intCount,
-    intIndex,
-    ix0,
-    ix1, ix2, ix3,
-  )
+import Covenant.DeBruijn (DeBruijn (S, Z), asInt)
+import Covenant.Index (Count, Index, count0, count1, count2, intCount, intIndex, ix0, ix1, ix2, ix3)
 import Covenant.Internal.KindCheck
   ( checkDataDecls,
     checkEncodingArgs,
@@ -147,7 +139,8 @@ import Covenant.Internal.Term
   ( ASGNodeType (CompNodeType, ValNodeType),
     Arg (UnsafeMkArg),
     Id (UnsafeMkId),
-    typeId, Ref,
+    Ref,
+    typeId,
   )
 import Covenant.Internal.Type
   ( AbstractTy (BoundAt),
@@ -169,10 +162,12 @@ import Covenant.Internal.Type
     runConstructorName,
   )
 import Covenant.Internal.Unification (checkApp)
+import Covenant.Prim (ThreeArgFunc (IfThenElse), TwoArgFunc (EqualsInteger))
 import Covenant.Type
-  ( CompT (Comp0, CompN, Comp2, Comp1),
-    CompTBody (ArgsAndResult, (:--:>), ReturnT),
-    tyvar, boolT,
+  ( CompT (Comp0, Comp1, Comp2, CompN),
+    CompTBody (ArgsAndResult, ReturnT, (:--:>)),
+    boolT,
+    tyvar,
   )
 import Covenant.Util (prettyStr)
 import Data.Coerce (coerce)
@@ -187,6 +182,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
+import Data.Wedge (Wedge (Here))
 import GHC.Exts (fromListN)
 import GHC.Word (Word32)
 import Optics.Core
@@ -218,12 +214,6 @@ import Test.QuickCheck.GenT qualified as GT
 import Test.QuickCheck.Instances.Containers ()
 import Test.QuickCheck.Instances.Vector ()
 import Test.Tasty.HUnit (assertFailure)
-import Covenant.Index (Index)
-import Covenant.ASG (Ref(AnArg))
-import Covenant.ASG (Ref(AnId))
-import Covenant.Constant (AConstant(AnInteger, ABoolean))
-import Covenant.Prim (ThreeArgFunc(IfThenElse), TwoArgFunc (EqualsInteger))
-import Data.Wedge (Wedge(Here))
 
 -- | Wrapper for 'ValT' to provide an 'Arbitrary' instance to generate only
 -- value types without any type variables.
@@ -1041,22 +1031,23 @@ concretifyMinimalBuilder = lam topLevelTy body
       boolArg <- AnArg <$> arg Z ix1
       fElim <- fPolyOneElimMinimal
       maybeInt <- ctor' "Maybe" "Just" [intArg]
-      AnId <$> app' fElim [AnId maybeInt,boolArg]
+      AnId <$> app' fElim [AnId maybeInt, boolArg]
 
     fPolyOneElimMinimal :: ASGBuilder Id
-    fPolyOneElimMinimal =  lam fPolyOneElimTy $ do
+    fPolyOneElimMinimal = lam fPolyOneElimTy $ do
       maybeA <- AnArg <$> arg Z ix0
       nothingHandler <- lazyLam (Comp0 $ ReturnT intT) $ do
         AnId <$> lit (AnInteger 0)
       justHandler <- lazyLam (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT intT) $ do
         AnId <$> lit (AnInteger 0)
-      AnId <$> match maybeA [AnId justHandler,AnId nothingHandler]
-     where
-       fPolyOneElimTy :: CompT AbstractTy
-       fPolyOneElimTy = Comp2 $ -- forall a b.
-                        mkMaybeT (tyvar Z ix0) -- Maybe a
-                        :--:> tyvar Z ix1 -- b
-                        :--:> ReturnT intT -- Int
+      AnId <$> match maybeA [AnId justHandler, AnId nothingHandler]
+      where
+        fPolyOneElimTy :: CompT AbstractTy
+        fPolyOneElimTy =
+          Comp2 $ -- forall a b.
+            mkMaybeT (tyvar Z ix0) -- Maybe a
+              :--:> tyvar Z ix1 -- b
+              :--:> ReturnT intT -- Int
 
 -- This is a torture test example. We'll use it here since we have it and it's relevant, but it's largely
 -- designed for a test in the code generator.
@@ -1073,18 +1064,17 @@ concretifyMegaTest = lam topLevelTy body
       mConst <- AnId <$> (thunk =<< monoConst)
       fIntro <- fPolyOneIntro
       fElim <- fPolyOneElim
-      introApplied <- app' fIntro [fmono,mConst,gmono,intArg,boolArg]
+      introApplied <- app' fIntro [fmono, mConst, gmono, intArg, boolArg]
       -- REVIEW @Koz: You said that a fully polymorphic identity function *should not work* as the second arg here, but it does work?
-      AnId <$> app' fElim [AnId introApplied,idF,boolArg,fmono]
+      AnId <$> app' fElim [AnId introApplied, idF, boolArg, fmono]
 
-    ifte ::  ASGBuilder Id
-    ifte  = lam (Comp1 $ boolT :--:> tyvar Z ix0 :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
+    ifte :: ASGBuilder Id
+    ifte = lam (Comp1 $ boolT :--:> tyvar Z ix0 :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
       cond <- AnArg <$> arg Z ix0
-      t    <- AnArg <$> arg Z ix1
-      f    <- AnArg <$> arg Z ix2
+      t <- AnArg <$> arg Z ix1
+      f <- AnArg <$> arg Z ix2
       ifThen <- builtin3 IfThenElse
-      AnId <$> app' ifThen [cond,t,f]
-
+      AnId <$> app' ifThen [cond, t, f]
 
     -- NOTE: I wonder what happens if we tried to define id and monoConst in terms of each other?
     --       Like if we do it so that we get infinite mutual recursion. I should probably *try*
@@ -1095,7 +1085,7 @@ concretifyMegaTest = lam topLevelTy body
       mConst <- monoConst
       x <- AnArg <$> arg Z ix0
       -- Might not need the ty app?
-      AnId <$> app' mConst [x,x] -- [Here tyX]
+      AnId <$> app' mConst [x, x] -- [Here tyX]
 
     -- forall a. a -> a -> a
     monoConst :: ASGBuilder Id
@@ -1114,22 +1104,21 @@ concretifyMegaTest = lam topLevelTy body
         b <- AnArg <$> arg (S Z) ix2
         bToInt <- force . AnArg =<< arg (S Z) ix3
         x <- AnId <$> app' bToInt [b]
-        AnId <$> app' mConst [zero,x]
+        AnId <$> app' mConst [zero, x]
       justHandler <- lazyLam (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT intT) $ do
         aToInt <- force . AnArg =<< arg (S Z) ix1
         a <- AnArg <$> arg Z ix0
         AnId <$> app' aToInt [a]
       AnId <$> match maybeA [AnId justHandler, AnId nothingHandler] -- ,AnId justHandler]
-     where
-       fPolyOneElimTy :: CompT AbstractTy
-       fPolyOneElimTy = Comp2 $ -- forall a b.
-                        mkMaybeT (tyvar Z ix0) -- Maybe a
-                        :--:> thunk0 (tyvar (S Z) ix0 :--:> ReturnT intT) -- (a -> Int)
-                        :--:> tyvar Z ix1 -- b
-                        :--:> thunk0 (tyvar (S Z) ix1 :--:> ReturnT intT) -- (b -> Int)
-                        :--:> ReturnT intT -- Int
-
-
+      where
+        fPolyOneElimTy :: CompT AbstractTy
+        fPolyOneElimTy =
+          Comp2 $ -- forall a b.
+            mkMaybeT (tyvar Z ix0) -- Maybe a
+              :--:> thunk0 (tyvar (S Z) ix0 :--:> ReturnT intT) -- (a -> Int)
+              :--:> tyvar Z ix1 -- b
+              :--:> thunk0 (tyvar (S Z) ix1 :--:> ReturnT intT) -- (b -> Int)
+              :--:> ReturnT intT -- Int
     fPolyOneIntro :: ASGBuilder Id
     fPolyOneIntro = lam fPolyOneIntroTy $ do
       fba <- force . AnArg =<< arg Z ix0
@@ -1139,42 +1128,42 @@ concretifyMegaTest = lam topLevelTy body
       b <- AnArg <$> arg Z ix4
       -- let ba = fba (monoConst b b)
       mConst <- monoConst
-      fbaArg <- AnId <$> app' mConst [b,b]
+      fbaArg <- AnId <$> app' mConst [b, b]
       ba <- AnId <$> app' fba [fbaArg]
       -- let aaa = monoConst a (faa a ba)
-      aaaArg <- AnId <$> app' faa [a,ba]
-      aaa <- AnId <$> app' mConst [a,aaaArg]
+      aaaArg <- AnId <$> app' faa [a, ba]
+      aaa <- AnId <$> app' mConst [a, aaaArg]
       -- if (predA aaa) then Nothing else Just aaa
       tvA <- boundTyVar Z ix0
       nothing <- ctor "Maybe" "Nothing" [] [Here tvA]
       justAAA <- ctor' "Maybe" "Just" [aaa]
       ifThen <- ifte
       cond <- app' predA [aaa]
-      AnId <$> app' ifThen [AnId cond,AnId nothing,AnId justAAA]
-     where
-       fPolyOneIntroTy :: CompT AbstractTy
-       fPolyOneIntroTy = Comp2 $ -- forall a b.
-                         ThunkT (Comp0 $ tyvar (S Z) ix1 :--:> ReturnT (tyvar (S Z) ix0)) -- (b -> a)
-                         :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> tyvar (S Z) ix0 :--:> ReturnT (tyvar (S Z) ix0)) -- (a -> a -> a)
-                         :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT boolT) -- (a -> Bool)
-                         :--:> tyvar Z ix0 -- a
-                         :--:> tyvar Z ix1 -- b
-                         :--:> ReturnT (mkMaybeT (tyvar Z ix0)) -- Maybe a
-
+      AnId <$> app' ifThen [AnId cond, AnId nothing, AnId justAAA]
+      where
+        fPolyOneIntroTy :: CompT AbstractTy
+        fPolyOneIntroTy =
+          Comp2 $ -- forall a b.
+            ThunkT (Comp0 $ tyvar (S Z) ix1 :--:> ReturnT (tyvar (S Z) ix0)) -- (b -> a)
+              :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> tyvar (S Z) ix0 :--:> ReturnT (tyvar (S Z) ix0)) -- (a -> a -> a)
+              :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT boolT) -- (a -> Bool)
+              :--:> tyvar Z ix0 -- a
+              :--:> tyvar Z ix1 -- b
+              :--:> ReturnT (mkMaybeT (tyvar Z ix0)) -- Maybe a
     fMono :: ASGBuilder Id
     fMono = lam (Comp0 $ boolT :--:> ReturnT intT) $ do
-          aBool <- AnArg <$> arg Z ix0
-          one <- AnId <$> lit (AnInteger 1)
-          zero <- AnId <$> lit (AnInteger 0)
-          ifThen <- ifte
-          AnId <$> app' ifThen [aBool,one,zero] 
+      aBool <- AnArg <$> arg Z ix0
+      one <- AnId <$> lit (AnInteger 1)
+      zero <- AnId <$> lit (AnInteger 0)
+      ifThen <- ifte
+      AnId <$> app' ifThen [aBool, one, zero]
 
     gMono :: ASGBuilder Id
     gMono = lam (Comp0 $ intT :--:> ReturnT boolT) $ do
-          anInt <- AnArg <$> arg Z ix0
-          zero <- AnId <$> lit (AnInteger 0)
-          cond <- anInt #== zero
-          ifThen <- ifte
-          false <- AnId <$> lit (ABoolean False)
-          troo  <- AnId <$> lit (ABoolean True)
-          AnId <$> app' ifThen [cond,false,troo]
+      anInt <- AnArg <$> arg Z ix0
+      zero <- AnId <$> lit (AnInteger 0)
+      cond <- anInt #== zero
+      ifThen <- ifte
+      false <- AnId <$> lit (ABoolean False)
+      troo <- AnId <$> lit (ABoolean True)
+      AnId <$> app' ifThen [cond, false, troo]

--- a/src/Covenant/Type.hs
+++ b/src/Covenant/Type.hs
@@ -235,9 +235,10 @@ pattern Comp3 xs <- (countHelper 3 -> Just xs)
 --
 -- @since 1.0.0
 pattern CompN ::
+  forall (a :: Type).
   Count "tyvar" ->
-  CompTBody AbstractTy ->
-  CompT AbstractTy
+  CompTBody a ->
+  CompT a
 pattern CompN count xs <- CompT count xs
   where
     CompN count xs = CompT count xs

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -74,9 +74,11 @@ import Covenant.Prim
 import Covenant.Test
   ( Concrete (Concrete),
     DebugASGBuilder,
+    concretifyMegaTest,
+    concretifyMinimalBuilder,
     debugASGBuilder,
     tyAppTestDatatypes,
-    typeIdTest, concretifyMinimalBuilder, concretifyMegaTest,
+    typeIdTest,
   )
 import Covenant.Type
   ( AbstractTy,
@@ -841,7 +843,6 @@ argBugUnitTest = testCase "argBugTest" $ withCompilationSuccessUnit asg (\_ -> p
         AnArg <$> arg (S Z) ix0
       one <- AnId <$> lit (AnInteger 1)
       AnId <$> app' gimmeZ0 [one]
-
 
 -- tests for our concretification fix in `app`.
 -- We only care that compilation succeeds.

--- a/test/asg/Main.hs
+++ b/test/asg/Main.hs
@@ -76,7 +76,7 @@ import Covenant.Test
     DebugASGBuilder,
     debugASGBuilder,
     tyAppTestDatatypes,
-    typeIdTest,
+    typeIdTest, concretifyMinimalBuilder, concretifyMegaTest,
   )
 import Covenant.Type
   ( AbstractTy,
@@ -166,7 +166,8 @@ main =
         "Opaque"
         [unifyOpaque],
       testGroup "matchOpaque" [matchOpaque],
-      testGroup "argBugTest" [argBugUnitTest]
+      testGroup "argBugTest" [argBugUnitTest],
+      testGroup "concretify" [simpleConcretifyUnitTest, excessiveConcretifyUnitTest]
     ]
   where
     moreTests :: QuickCheckTests -> QuickCheckTests
@@ -830,7 +831,7 @@ matchOpaque = runIntroFormTest "matchOpaque" matchOpaqueTy $ do
     matchOpaqueTy = ThunkT matchOpaqueCompTy
 
 argBugUnitTest :: TestTree
-argBugUnitTest = testCase "argBugTest" $ withCompilationSuccessUnit asg print
+argBugUnitTest = testCase "argBugTest" $ withCompilationSuccessUnit asg (\_ -> pure ())
   where
     intT :: ValT AbstractTy
     intT = BuiltinFlat IntegerT
@@ -840,6 +841,16 @@ argBugUnitTest = testCase "argBugTest" $ withCompilationSuccessUnit asg print
         AnArg <$> arg (S Z) ix0
       one <- AnId <$> lit (AnInteger 1)
       AnId <$> app' gimmeZ0 [one]
+
+
+-- tests for our concretification fix in `app`.
+-- We only care that compilation succeeds.
+
+simpleConcretifyUnitTest :: TestTree
+simpleConcretifyUnitTest = testCase "simpleConcretify" $ withCompilationSuccessUnit concretifyMinimalBuilder (\_ -> pure ())
+
+excessiveConcretifyUnitTest :: TestTree
+excessiveConcretifyUnitTest = testCase "excessiveConcretify" $ withCompilationSuccessUnit concretifyMegaTest (\_ -> pure ())
 
 -- Helpers
 

--- a/test/json-conformance/Main.hs
+++ b/test/json-conformance/Main.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedLists #-}
 
-module Main (main)  where
+module Main (main) where
 
 import Control.Monad (void)
 import Covenant.ASG
@@ -21,8 +21,9 @@ import Covenant.ASG
     lazyLam,
     lit,
     match,
-    runASGBuilder
+    runASGBuilder,
   )
+import Covenant.Constant (AConstant (AString, AnInteger))
 import Covenant.DeBruijn (DeBruijn (S, Z))
 import Covenant.Index (ix0, ix1)
 import Covenant.JSON (deserializeAndValidate_)
@@ -32,21 +33,12 @@ import Covenant.Test
     conformanceDatatypes2,
     unsafeMkDatatypeInfos,
   )
-import Covenant.Type
-  ( AbstractTy,
-    BuiltinFlatT (BoolT, IntegerT, StringT),
-    CompT (Comp0, Comp1),
-    CompTBody (ReturnT, (:--:>)),
-    ValT,
-    tyvar,
-  )
+import Covenant.Type (AbstractTy, BuiltinFlatT (BoolT, IntegerT, StringT), CompT (Comp0, Comp1), CompTBody (ReturnT, (:--:>)), ValT (BuiltinFlat), tyvar)
 import Data.Either (isRight)
 import Data.Vector qualified as Vector
 import Data.Wedge (Wedge (There))
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase)
-import Covenant.Type (ValT(BuiltinFlat))
-import Covenant.Constant (AConstant(AString, AnInteger))
 
 main :: IO ()
 main =
@@ -291,7 +283,6 @@ conformance_body2_builder = lam topLevelTy body
 
     maybeBoolT :: ValT AbstractTy
     maybeBoolT = dtype "Maybe" [boolT]
-
 
 _debugHelp :: ASGBuilder Id -> Either CovenantError ASG
 _debugHelp = runASGBuilder (unsafeMkDatatypeInfos conformanceDatatypes1)

--- a/test/json-conformance/Main.hs
+++ b/test/json-conformance/Main.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedLists #-}
 
-module Main  where
+module Main (main)  where
 
 import Control.Monad (void)
 import Covenant.ASG
@@ -21,13 +21,10 @@ import Covenant.ASG
     lazyLam,
     lit,
     match,
-    runASGBuilder, force, thunk, boundTyVar, builtin3, app,
-  )
-import Covenant.Constant
-  ( AConstant (AString, AnInteger),
+    runASGBuilder
   )
 import Covenant.DeBruijn (DeBruijn (S, Z))
-import Covenant.Index (ix0, ix1, intIndex, ix2, ix3)
+import Covenant.Index (ix0, ix1)
 import Covenant.JSON (deserializeAndValidate_)
 import Covenant.Prim (TwoArgFunc (AddInteger, EqualsInteger, SubtractInteger))
 import Covenant.Test
@@ -38,25 +35,18 @@ import Covenant.Test
 import Covenant.Type
   ( AbstractTy,
     BuiltinFlatT (BoolT, IntegerT, StringT),
-    CompT (..),
+    CompT (Comp0, Comp1),
     CompTBody (ReturnT, (:--:>)),
-    ValT (BuiltinFlat),
-    tyvar, boolT,
+    ValT,
+    tyvar,
   )
 import Data.Either (isRight)
 import Data.Vector qualified as Vector
-import Data.Wedge (Wedge (..))
+import Data.Wedge (Wedge (There))
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase)
-import Covenant.Type (ValT(..))
-import Covenant.ASG (ASGNode(..))
-import Covenant.ASG (Arg(Arg))
-import Covenant.Index (Index)
-import Optics.Core (preview)
-import Data.Maybe (fromJust)
-import Covenant.Constant (AConstant(..))
-import Control.Monad.HashCons (MonadHashCons(..))
-import Covenant.Prim (ThreeArgFunc(IfThenElse))
+import Covenant.Type (ValT(BuiltinFlat))
+import Covenant.Constant (AConstant(AString, AnInteger))
 
 main :: IO ()
 main =
@@ -302,249 +292,6 @@ conformance_body2_builder = lam topLevelTy body
     maybeBoolT :: ValT AbstractTy
     maybeBoolT = dtype "Maybe" [boolT]
 
-ix4 :: forall s. Index s
-ix4 = fromJust $ preview intIndex 4
 
-thunk0 = ThunkT . Comp0
-
-thunk2 = ThunkT . Comp2
-
-testFn :: Either CovenantError ASG
-testFn = runASGBuilder (unsafeMkDatatypeInfos conformanceDatatypes1) testFnBuilder
-
-debugHelp :: ASGBuilder Id -> Either CovenantError ASG
-debugHelp act = runASGBuilder (unsafeMkDatatypeInfos conformanceDatatypes1) act
-
-intT :: ValT AbstractTy
-intT = BuiltinFlat IntegerT
-
--- boolT :: ValT AbstractTy
--- boolT = BuiltinFlat BoolT
-
-maybeT :: ValT AbstractTy -> ValT AbstractTy
-maybeT t = dtype "Maybe" [t]
-
-ifte ::  ASGBuilder Id
-ifte  = lam (Comp1 $ boolT :--:> tyvar Z ix0 :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
-  cond <- AnArg <$> arg Z ix0
-  t    <- AnArg <$> arg Z ix1
-  f    <- AnArg <$> arg Z ix2
-  ifThen <- builtin3 IfThenElse
-  tvHere <- boundTyVar Z ix0
-  AnId <$> app' ifThen [cond,t,f] -- [Here tvHere]
-
-
--- NOTE: I wonder what happens if we tried to define id and monoConst in terms of each other?
---       Like if we do it so that we get infinite mutual recursion. I should probably *try*
---       to compile something like that just to see whether it explodes.
-identitee :: ASGBuilder Id
-identitee = lam (Comp1 $ tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
-  -- Not how you would typically implement `id` lol
-  mConst <- monoConst
-  tyX <- boundTyVar Z ix0
-  x <- AnArg <$> arg Z ix0
-  -- Might not need the ty app?
-  AnId <$> app' mConst [x,x] -- [Here tyX]
-
-
--- forall a. a -> a -> a
-monoConst :: ASGBuilder Id
-monoConst = lam (Comp1 $ tyvar Z ix0 :--:> tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
-  AnArg <$> arg Z ix1
-
-fPolyOneIntro :: ASGBuilder Id
-fPolyOneIntro = lam fPolyOneIntroTy $ do
-  fba <- force . AnArg =<< arg Z ix0
-  faa <- force . AnArg =<< arg Z ix1
-  predA <- force . AnArg =<< arg Z ix2
-  a <- AnArg <$> arg Z ix3
-  b <- AnArg <$> arg Z ix4
-  -- let ba = fba (monoConst b b)
-  mConst <- monoConst
-  fbaArg <- AnId <$> app' mConst [b,b]
-  ba <- AnId <$> app' fba [fbaArg]
-  -- let aaa = monoConst a (faa a ba)
-  aaaArg <- AnId <$> app' faa [a,ba]
-  aaa <- AnId <$> app' mConst [a,aaaArg]
-  -- if (predA aaa) then Nothing else Just aaa
-  tvA <- boundTyVar Z ix0
-  nothing <- ctor "Maybe" "Nothing" [] [Here tvA]
-  justAAA <- ctor' "Maybe" "Just" [aaa]
-  ifThen <- ifte
-  cond <- app' predA [aaa]
-  -- might need to do this w/ the explicit type app?
-  AnId <$> app' ifThen [AnId cond,AnId nothing,AnId justAAA]
- where
-   fPolyOneIntroTy :: CompT AbstractTy
-   fPolyOneIntroTy = Comp2 $ -- forall a b.
-                     ThunkT (Comp0 $ tyvar (S Z) ix1 :--:> ReturnT (tyvar (S Z) ix0)) -- (b -> a)
-                     :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> tyvar (S Z) ix0 :--:> ReturnT (tyvar (S Z) ix0)) -- (a -> a -> a)
-                     :--:> ThunkT (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT boolT) -- (a -> Bool)
-                     :--:> tyvar Z ix0 -- a
-                     :--:> tyvar Z ix1 -- b
-                     :--:> ReturnT (maybeT (tyvar Z ix0)) -- Maybe a
-
-fPolyOneElim :: ASGBuilder Id
-fPolyOneElim = lam fPolyOneElimTy $ do
-  false <- AnId <$> lit (ABoolean False)
-  zero <- AnId <$> lit (AnInteger 0)
-  maybeA <- AnArg <$> arg Z ix0
-  -- maybe we should move `b` into the nothingHandler so it blows up if there's a DB issue somewhere?
-  nothingHandler <- lazyLam (Comp0 $ ReturnT intT) $ do
-    --            x[       y[                 ]
-    -- monoConst 0 (bToInt (monoConst False b))
-    mConst <- monoConst
-    b <- AnArg <$> arg (S Z) ix2
-    bToInt <- force . AnArg =<< arg (S Z) ix3
-    -- y <- AnId <$> app' mConst [false,b]
-    x <- AnId <$> app' bToInt [b] -- [y]
-    -- AnId <$> app' mConst [zero,x]
-    AnId <$> lit (AnInteger 0)
-  justHandler <- lazyLam (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT intT) $ do
-    -- aToInt <- force . AnArg =<< arg (S Z) ix1
-    -- a <- AnArg <$> arg (S Z) ix0
-    -- AnId <$> app' aToInt [a]
-    AnId <$> lit (AnInteger 0)
-  AnId <$> match maybeA [AnId nothingHandler,AnId justHandler]
- where
-   fPolyOneElimTy :: CompT AbstractTy
-   fPolyOneElimTy = Comp2 $ -- forall a b.
-                    maybeT (tyvar Z ix0) -- Maybe a
-                    :--:> thunk0 (tyvar (S Z) ix0 :--:> ReturnT intT) -- (a -> Int)
-                    :--:> tyvar Z ix1 -- b
-                    :--:> thunk0 (tyvar (S Z) ix1 :--:> ReturnT intT) -- (b -> Int)
-                    :--:> ReturnT intT -- Int
-
-fPolyOneElimMinimal :: ASGBuilder Id
-fPolyOneElimMinimal =  lam fPolyOneElimTy $ do
-  maybeA <- AnArg <$> arg Z ix0
-  nothingHandler <- lazyLam (Comp0 $ ReturnT intT) $ do
-    AnId <$> lit (AnInteger 0)
-  justHandler <- lazyLam (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT intT) $ do
-    AnId <$> lit (AnInteger 0)
-  AnId <$> match maybeA [AnId nothingHandler,AnId justHandler]
- where
-   fPolyOneElimTy :: CompT AbstractTy
-   fPolyOneElimTy = Comp2 $ -- forall a b.
-                    maybeT (tyvar Z ix0) -- Maybe a
-                    :--:> tyvar Z ix1 -- b
-                    :--:> ReturnT intT -- Int
-
-testFnBuilder' :: ASGBuilder Id
-testFnBuilder' = lam topLevelTy body
-  where
-    topLevelTy :: CompT AbstractTy
-    topLevelTy = Comp0 $ intT :--:> boolT :--:> ReturnT intT
-
-    body :: ASGBuilder Ref
-    body = do
-      intArg <- AnArg <$> arg Z ix0
-      boolArg <- AnArg <$> arg Z ix1
-      fElim <- fPolyOneElimMinimal
-      maybeInt <- ctor' "Maybe" "Just" [intArg]
-      AnId <$> app' fElim [AnId maybeInt,boolArg]
-
-
-fPolyOneElimMinimal' :: ASGBuilder Id
-fPolyOneElimMinimal' =  lam fPolyOneElimTy $ do
-  maybeA <- AnArg <$> arg Z ix0
-  nothingHandler <- lazyLam (Comp0 $ ReturnT intT) $ do
-    AnId <$> lit (AnInteger 0)
-  justHandler <- lazyLam (Comp0 $ tyvar (S Z) ix0 :--:> ReturnT intT) $ do
-    AnId <$> lit (AnInteger 0)
-  AnId <$> match maybeA [AnId nothingHandler,AnId justHandler]
- where
-   fPolyOneElimTy :: CompT AbstractTy
-   fPolyOneElimTy = Comp1 $ -- forall a.
-                    maybeT (tyvar Z ix0) -- Maybe a
-                    :--:> ReturnT intT -- Int
-
-testFnBuilder'' :: ASGBuilder Id
-testFnBuilder'' = lam topLevelTy body
-  where
-    topLevelTy :: CompT AbstractTy
-    topLevelTy = Comp0 $ intT :--:> boolT :--:> ReturnT intT
-
-    body :: ASGBuilder Ref
-    body = do
-      intArg <- AnArg <$> arg Z ix0
-      fElim <- fPolyOneElimMinimal'
-      maybeInt <- ctor' "Maybe" "Just" [intArg]
-      AnId <$> app' fElim [AnId maybeInt]
-
-
-unsafeShowNodeType :: Id -> ASGBuilder String
-unsafeShowNodeType i = lookupRef i >>= \case
-  Nothing -> error "boom"
-  Just aNode -> case aNode of
-    AValNode t _ -> pure $ show t
-    ACompNode t _ -> pure $ show t
-    _ -> error "error node type"
-
-unsafeShowRefType :: Ref -> ASGBuilder String
-unsafeShowRefType = \case
-  AnArg (Arg _ _ t) -> pure (show t)
-  AnId i -> unsafeShowNodeType i
-
-testFnBuilder :: ASGBuilder Id
-testFnBuilder = lam topLevelTy body
-  where
-    topLevelTy :: CompT AbstractTy
-    topLevelTy = Comp0 $ intT :--:> boolT :--:> ReturnT intT
-
-    body :: ASGBuilder Ref
-    body = do
-      intArg <- AnArg <$> arg Z ix0
-      boolArg <- AnArg <$> arg Z ix1
-      idF <- AnId <$> (thunk =<< identitee)
-      fmono <- AnId <$> (thunk =<< fMono)
-      gmono <- AnId <$> (thunk =<< gMono)
-      mConst <- AnId <$> (thunk =<< monoConst)
-      intId <- AnId <$> (thunk =<< (lam (Comp0 $ intT :--:> ReturnT intT) (AnArg <$> arg Z ix0)))
-      intConst <- AnId <$> (thunk =<< (lam (Comp0 $ intT :--:> intT :--:> ReturnT intT) (AnArg <$> arg Z ix1)))
-      fIntro <- fPolyOneIntro
-      fElim <- fPolyOneElim
-      introApplied <- app' fIntro [fmono,mConst,gmono,intArg,boolArg]
-      fElimTyStr <- unsafeShowNodeType fElim
-      introAppliedTyStr <- unsafeShowNodeType introApplied
-      idFTyStr <- unsafeShowRefType intId
-      boolArgTyStr <- unsafeShowRefType boolArg
-      fMonoTyStr   <- unsafeShowRefType fmono
-      let msg :: String
-          msg = concatMap (\(x :: String) -> x <> "\n\n" :: String)
-                (  [ "fElimTy: " <> fElimTyStr
-                , "introAppliedTy: " <> introAppliedTyStr
-                , "idFTyStr: " <> idFTyStr
-                , "boolArgTyStr: " <> boolArgTyStr
-                , "fmonoTyStr: " <> fMonoTyStr
-                ] :: [String])
-      --error ("\n\n" <> msg)
-      AnId <$> app' fElim [AnId introApplied,intId,boolArg,fmono]
-
-fMono :: ASGBuilder Id
-fMono = lam (Comp0 $ boolT :--:> ReturnT intT) $ do
-      aBool <- AnArg <$> arg Z ix0
-      one <- AnId <$> lit (AnInteger 1)
-      zero <- AnId <$> lit (AnInteger 0)
-      ifThen <- ifte
-      AnId <$> app' ifThen [aBool,one,zero] -- [There (BuiltinFlat IntegerT)]
-
-gMono :: ASGBuilder Id
-gMono = lam (Comp0 $ intT :--:> ReturnT boolT) $ do
-      anInt <- AnArg <$> arg Z ix0
-      zero <- AnId <$> lit (AnInteger 0)
-      cond <- anInt #== zero
-      ifThen <- ifte
-      false <- AnId <$> lit (ABoolean False)
-      troo  <- AnId <$> lit (ABoolean True)
-      AnId <$> app' ifThen [cond,false,troo]
-
-
-
-
-minimalArgBugExample :: ASGBuilder Id
-minimalArgBugExample = lam (Comp1 $ tyvar Z ix0 :--:> ReturnT (tyvar Z ix0)) $ do
-  gimmeZ0 <- lam (Comp0 $ intT :--:> ReturnT (tyvar (S Z) ix0)) $ do
-    AnArg <$> arg (S Z) ix0
-  one <- AnId <$> lit (AnInteger 1)
-  AnId <$> app' gimmeZ0 [one]
+_debugHelp :: ASGBuilder Id -> Either CovenantError ASG
+_debugHelp = runASGBuilder (unsafeMkDatatypeInfos conformanceDatatypes1)


### PR DESCRIPTION
Replaces the `zipWithM unify` machinery in `app` with "structural" (non-BBF-based) machinery for determining the concretification of functions being applied. Adds a few tests to verify the behavior. 